### PR TITLE
UN-3077 Fix the problem with setting default field values for Http server logging.

### DIFF
--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -66,7 +66,7 @@ class BaseRequestHandler(RequestHandler):
         self.port: int = port
         self.forwarded_request_metadata: List[str] = forwarded_request_metadata
         self.openapi_service_spec_path: str = openapi_service_spec_path
-        self.logger = HttpLogger()
+        self.logger = HttpLogger(forwarded_request_metadata)
 
         if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
             self.set_header("Access-Control-Allow-Origin", "*")

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -62,7 +62,7 @@ class HttpSidecar:
         Method to be called by a process running tornado HTTP server
         to actually start serving requests.
         """
-        self.logger = HttpLogger()
+        self.logger = HttpLogger(self.forwarded_request_metadata)
 
         app = self.make_app()
         app.listen(self.http_port)


### PR DESCRIPTION
This PR makes sure that for any http logger call, our logger filter sets up logging record at least with some default value ("None") for every key from forwarded request meta-data.
The problem shows up actually when we use Http logger outside of request handling context,
but this case is now fixed too.
