### PR TITLE
UN-3075 max_message_history

### DIFF
--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -212,7 +212,9 @@ class DataDrivenChatSession:
                 the conversation such that it could be taken up on a different
                 server instance
         """
-        processor: MessageProcessor = ChatHistoryMessageProcessor()
+        # OK if this is None
+        max_message_history: int = self.front_man.get_agent_tool_spec().get("max_message_history")
+        processor: MessageProcessor = ChatHistoryMessageProcessor(max_message_history)
         processor.process_messages(chat_message_history)
 
         chat_history: Dict[str, Any] = {


### PR DESCRIPTION
Requested by 1C guys.

Allow a "max_message_history" on the front man agent spec to potentially limit the number of messages sent back in the chat history. Preserved context favors the N most recent messages.

This becomes a somewhat simple/reasonable way to deal with input context limits for long conversations like 1C has without getting into the nitty-gritty of token counting and input context limits when agents can now have fallback llms of varying capabilities.  Some of the 1C responses get pretty long and the number of interactions can be pretty high as well.

Tested: music_nerd_pro with and without a max_message_history of 2.
Q: Who did Yellow Submarine?
A: Beatles
Q: Where were they from?
A: Liverpool
Q: What album was it on?
A: Revolver     <- No max_message_history
A: What are you talking about? <- max_message_history = 2  (Yellow Submarine is out of context now)