### PR TITLE
UN-3084-neuro-san-typo-for-claude-3-opus-model-in-default-llm-info-hoconFix typo in default_llm_info.hocon

### DIFF
--- a/neuro_san/internals/run_context/langchain/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/default_llm_info.hocon
@@ -288,7 +288,7 @@
     },
 
     "claude-3-opus": {
-        "class": "anthropic",
+        "use_model_name": "claude-3-opus-20240229",
     },
     "claude-3-opus-20240229": {
         "class": "anthropic",


### PR DESCRIPTION
## Changes
- Fix typo in default_llm_info.hocon.

## Tests
- Run agent hocon with claude-3-opus model.

