### PR TITLE
UN-2778 Dynamic routing of Http requests to agents.

### DIFF
--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -25,6 +25,7 @@ import grpc
 from tornado.web import RequestHandler
 
 from neuro_san.http_sidecar.logging.http_logger import HttpLogger
+from neuro_san.http_sidecar.interfaces.agent_authorizer import AgentAuthorizer
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
 from neuro_san.interfaces.concierge_session import ConciergeSession
 from neuro_san.session.async_grpc_service_agent_session import AsyncGrpcServiceAgentSession
@@ -51,12 +52,15 @@ class BaseRequestHandler(RequestHandler):
     request_id: int = 0
 
     # pylint: disable=attribute-defined-outside-init
-    def initialize(self, agent_policy, port,
-                   forwarded_request_metadata, openapi_service_spec_path):
+    def initialize(self,
+                   agent_policy: AgentAuthorizer,
+                   port: int,
+                   forwarded_request_metadata: List[str],
+                   openapi_service_spec_path: str):
         """
         This method is called by Tornado framework to allow
         injecting service-specific data into local handler context.
-        :param agent_name: name of receiving neuro-san agent
+        :param agent_policy: abstract policy for agent requests
         :param port: gRPC service port.
         :param forwarded_request_metadata: request metadata to forward.
         :param openapi_service_spec_path: file path to OpenAPI service spec.

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -51,7 +51,7 @@ class BaseRequestHandler(RequestHandler):
     request_id: int = 0
 
     # pylint: disable=attribute-defined-outside-init
-    def initialize(self, agent_name, port,
+    def initialize(self, agent_policy, port,
                    forwarded_request_metadata, openapi_service_spec_path):
         """
         This method is called by Tornado framework to allow
@@ -62,7 +62,7 @@ class BaseRequestHandler(RequestHandler):
         :param openapi_service_spec_path: file path to OpenAPI service spec.
         """
 
-        self.agent_name: str = agent_name
+        self.agent_policy = agent_policy
         self.port: int = port
         self.forwarded_request_metadata: List[str] = forwarded_request_metadata
         self.openapi_service_spec_path: str = openapi_service_spec_path
@@ -92,7 +92,9 @@ class BaseRequestHandler(RequestHandler):
                 result[item_name] = "None"
         return result
 
-    def get_agent_grpc_session(self, metadata: Dict[str, Any]) -> AsyncAgentSession:
+    def get_agent_grpc_session(self,
+                               metadata: Dict[str, Any],
+                               agent_name: str) -> AsyncAgentSession:
         """
         Build gRPC session to talk to "main" service
         :return: AgentSession to use
@@ -102,7 +104,7 @@ class BaseRequestHandler(RequestHandler):
                 host="localhost",
                 port=self.port,
                 metadata=metadata,
-                agent_name=self.agent_name)
+                agent_name=agent_name)
         return grpc_session
 
     def get_concierge_grpc_session(self, metadata: Dict[str, Any]) -> ConciergeSession:

--- a/neuro_san/http_sidecar/handlers/concierge_handler.py
+++ b/neuro_san/http_sidecar/handlers/concierge_handler.py
@@ -28,7 +28,7 @@ class ConciergeHandler(BaseRequestHandler):
         Implementation of GET request handler for "concierge" API call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        self.logger.info(metadata, "Start GET %s/list", self.agent_name)
+        self.logger.info(metadata, "Start GET /api/v1/list")
         try:
             data: Dict[str, Any] = {}
             grpc_session: ConciergeSession = self.get_concierge_grpc_session(metadata)
@@ -42,4 +42,4 @@ class ConciergeHandler(BaseRequestHandler):
             self.process_exception(exc)
         finally:
             self.flush()
-            self.logger.info(metadata, "Finish GET %s/list", self.agent_name)
+            self.logger.info(metadata, "Finish GET /api/v1/list")

--- a/neuro_san/http_sidecar/handlers/connectivity_handler.py
+++ b/neuro_san/http_sidecar/handlers/connectivity_handler.py
@@ -23,7 +23,7 @@ class ConnectivityHandler(BaseRequestHandler):
     Handler class for neuro-san "connectivity" API call.
     """
 
-    async def get(self, agent_name):
+    async def get(self, agent_name: str):
         """
         Implementation of GET request handler for "connectivity" API call.
         """

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -23,7 +23,7 @@ class FunctionHandler(BaseRequestHandler):
     Handler class for neuro-san "function" API call.
     """
 
-    async def get(self, agent_name):
+    async def get(self, agent_name: str):
         """
         Implementation of GET request handler for "function" API call.
         """

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -23,16 +23,22 @@ class FunctionHandler(BaseRequestHandler):
     Handler class for neuro-san "function" API call.
     """
 
-    async def get(self):
+    async def get(self, agent_name):
         """
         Implementation of GET request handler for "function" API call.
         """
+        if not self.agent_policy.allow(agent_name):
+            self.set_status(404)
+            self.logger.error({}, "error: Invalid request path %s", self.request.path)
+            await self.flush()
+            return
 
         metadata: Dict[str, Any] = self.get_metadata()
-        self.logger.info(metadata, "Start GET %s/function", self.agent_name)
+        self.logger.info(metadata, "Start GET %s/function", agent_name)
         try:
             data: Dict[str, Any] = {}
-            grpc_session: AsyncAgentSession = self.get_agent_grpc_session(metadata)
+            grpc_session: AsyncAgentSession =\
+                self.get_agent_grpc_session(metadata, agent_name)
             result_dict: Dict[str, Any] = await grpc_session.function(data)
 
             # Return gRPC response to the HTTP client
@@ -43,4 +49,4 @@ class FunctionHandler(BaseRequestHandler):
             self.process_exception(exc)
         finally:
             await self.flush()
-            self.logger.info(metadata, "Finish GET %s/function", self.agent_name)
+            self.logger.info(metadata, "Finish GET %s/function", agent_name)

--- a/neuro_san/http_sidecar/handlers/openapi_publish_handler.py
+++ b/neuro_san/http_sidecar/handlers/openapi_publish_handler.py
@@ -29,7 +29,7 @@ class OpenApiPublishHandler(BaseRequestHandler):
         for "publish my OpenAPI specification document" call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        self.logger.info(metadata, "Start GET %s/docs", self.agent_name)
+        self.logger.info(metadata, "Start GET /api/v1/docs")
         try:
             with open(self.openapi_service_spec_path, "r", encoding='utf-8') as f_out:
                 result_dict: Dict[str, Any] = json.load(f_out)
@@ -40,4 +40,4 @@ class OpenApiPublishHandler(BaseRequestHandler):
             self.process_exception(exc)
         finally:
             self.flush()
-            self.logger.info(metadata, "Finish GET %s/docs", self.agent_name)
+            self.logger.info(metadata, "Finish GET /api/v1/docs")

--- a/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
+++ b/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
@@ -55,7 +55,7 @@ class StreamingChatHandler(BaseRequestHandler):
                 sent_out += 1
         return sent_out
 
-    async def post(self, agent_name):
+    async def post(self, agent_name: str):
         """
         Implementation of POST request handler for streaming chat API call.
         """

--- a/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
+++ b/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
@@ -55,19 +55,25 @@ class StreamingChatHandler(BaseRequestHandler):
                 sent_out += 1
         return sent_out
 
-    async def post(self):
+    async def post(self, agent_name):
         """
         Implementation of POST request handler for streaming chat API call.
         """
+        if not self.agent_policy.allow(agent_name):
+            self.set_status(404)
+            self.logger.error({}, "error: Invalid request path %s", self.request.path)
+            await self.flush()
+            return
+
         metadata: Dict[str, Any] = self.get_metadata()
-        self.logger.info(metadata, "Start POST %s/streaming_chat", self.agent_name)
+        self.logger.info(metadata, "Start POST %s/streaming_chat", agent_name)
         sent_out = 0
         try:
             # Parse JSON body
             data = json.loads(self.request.body)
 
             grpc_request = Parse(json.dumps(data), ChatRequest())
-            grpc_session: AsyncAgentSession = self.get_agent_grpc_session(metadata)
+            grpc_session: AsyncAgentSession = self.get_agent_grpc_session(metadata, agent_name)
 
             # Mind the type hint:
             # here we are getting Generator of Generators of ChatResponses!
@@ -81,7 +87,7 @@ class StreamingChatHandler(BaseRequestHandler):
             await self.flush()
             # We are done with response stream:
             await self.finish()
-            self.logger.info(metadata, "Finish POST %s/streaming_chat %d responses", self.agent_name, sent_out)
+            self.logger.info(metadata, "Finish POST %s/streaming_chat %d responses", agent_name, sent_out)
 
     async def options(self):
         """

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -88,6 +88,7 @@ class HttpSidecar(AgentAuthorizer):
         handlers.append(("/api/v1/docs", OpenApiPublishHandler, request_data))
 
         # Register templated request paths for agent API methods:
+        # regexp format used here is that of Python Re standard library.
         handlers.append((r"/api/v1/([^/]+)/function", FunctionHandler, request_data))
         handlers.append((r"/api/v1/([^/]+)/connectivity", ConnectivityHandler, request_data))
         handlers.append((r"/api/v1/([^/]+)/streaming_chat", StreamingChatHandler, request_data))
@@ -100,7 +101,6 @@ class HttpSidecar(AgentAuthorizer):
     def build_request_data(self) -> Dict[str, Any]:
         """
         Build request data for Http handlers.
-        :param agent_name: name of an agent this request data is for.
         :return: a dictionary with request data to be passed to a http handler.
         """
         return {

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -71,6 +71,7 @@ class HttpSidecar(AgentAuthorizer):
         self.logger.info({}, "HTTP server is running on port %d", self.http_port)
         self.logger.debug({}, "Serving agents: %s", repr(self.agents.keys()))
         # Put agent names into "allowed" list:
+        self.allowed_agents = {}
         for agent_name, _ in self.agents.items():
             self.allowed_agents[agent_name] = True
         IOLoop.current().start()

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -37,6 +37,7 @@ class HttpSidecar(AgentAuthorizer):
     working as a client to neuro-san gRPC service.
     """
     # pylint: disable=too-many-arguments, too-many-positional-arguments
+    # pylint: disable=too-many-instance-attributes
     def __init__(self, port: int, http_port: int,
                  agents: Dict[str, Any],
                  openapi_service_spec_path: str,

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -22,6 +22,7 @@ from tornado.web import Application
 from neuro_san.http_sidecar.logging.http_logger import HttpLogger
 from neuro_san.service.agent_server import DEFAULT_FORWARDED_REQUEST_METADATA
 
+from neuro_san.http_sidecar.interfaces.agent_authorizer import AgentAuthorizer
 from neuro_san.http_sidecar.handlers.health_check_handler import HealthCheckHandler
 from neuro_san.http_sidecar.handlers.connectivity_handler import ConnectivityHandler
 from neuro_san.http_sidecar.handlers.function_handler import FunctionHandler
@@ -30,7 +31,7 @@ from neuro_san.http_sidecar.handlers.concierge_handler import ConciergeHandler
 from neuro_san.http_sidecar.handlers.openapi_publish_handler import OpenApiPublishHandler
 
 
-class HttpSidecar:
+class HttpSidecar(AgentAuthorizer):
     """
     Class provides simple http endpoint for neuro-san API,
     working as a client to neuro-san gRPC service.
@@ -56,6 +57,7 @@ class HttpSidecar:
         self.logger = None
         self.openapi_service_spec_path: str = openapi_service_spec_path
         self.forwarded_request_metadata: List[str] = forwarded_request_metadata.split(" ")
+        self.allowed_agents: Dict[str, bool] = {}
 
     def __call__(self):
         """
@@ -68,46 +70,39 @@ class HttpSidecar:
         app.listen(self.http_port)
         self.logger.info({}, "HTTP server is running on port %d", self.http_port)
         self.logger.debug({}, "Serving agents: %s", repr(self.agents.keys()))
+        # Put agent names into "allowed" list:
+        for agent_name, _ in self.agents.items():
+            self.allowed_agents[agent_name] = True
         IOLoop.current().start()
 
     def make_app(self):
         """
         Construct tornado HTTP "application" to run.
         """
+        request_data: Dict[str, Any] = self.build_request_data()
         handlers = []
         handlers.append(("/", HealthCheckHandler))
-        concierge_data: Dict[str, Any] = self.build_request_data("concierge")
-        handlers.append(("/api/v1/list", ConciergeHandler, concierge_data))
-        openapi_spec_data: Dict[str, Any] = self.build_request_data("openapi")
-        handlers.append(("/api/v1/docs", OpenApiPublishHandler, openapi_spec_data))
+        handlers.append(("/api/v1/list", ConciergeHandler, request_data))
+        handlers.append(("/api/v1/docs", OpenApiPublishHandler, request_data))
 
-        for agent_name in self.agents.keys():
-            # For each of registered agents, we define 3 request paths -
-            # one for each of neuro-san service API methods.
-            # For each request http path, we build corresponding request handler
-            # and put it in "handlers" list,
-            # which is used to construct tornado "application".
-            request_data: Dict[str, Any] = self.build_request_data(agent_name)
-            route: str = f"/api/v1/{agent_name}/connectivity"
-            handlers.append((route, ConnectivityHandler, request_data))
-            self.logger.info({}, "Registering URL path: %s", route)
-            route: str = f"/api/v1/{agent_name}/function"
-            handlers.append((route, FunctionHandler, request_data))
-            self.logger.info({}, "Registering URL path: %s", route)
-            route: str = f"/api/v1/{agent_name}/streaming_chat"
-            handlers.append((route, StreamingChatHandler, request_data))
-            self.logger.info({}, "Registering URL path: %s", route)
+        # Register templated request paths for agent API methods:
+        handlers.append((r"/api/v1/([^/]+)/function", FunctionHandler, request_data))
+        handlers.append((r"/api/v1/([^/]+)/connectivity", ConnectivityHandler, request_data))
+        handlers.append((r"/api/v1/([^/]+)/streaming_chat", StreamingChatHandler, request_data))
 
         return Application(handlers)
 
-    def build_request_data(self, agent_name: str) -> Dict[str, Any]:
+    def allow(self, agent_name) -> bool:
+        return self.allowed_agents.get(agent_name, False)
+
+    def build_request_data(self) -> Dict[str, Any]:
         """
         Build request data for Http handlers.
         :param agent_name: name of an agent this request data is for.
         :return: a dictionary with request data to be passed to a http handler.
         """
         return {
-            "agent_name": agent_name,
+            "agent_policy": self,
             "port": self.port,
             "forwarded_request_metadata": self.forwarded_request_metadata,
             "openapi_service_spec_path": self.openapi_service_spec_path

--- a/neuro_san/http_sidecar/interfaces/agent_authorizer.py
+++ b/neuro_san/http_sidecar/interfaces/agent_authorizer.py
@@ -13,6 +13,7 @@
 See class comment for details
 """
 
+
 class AgentAuthorizer:
     """
     Abstract interface implementing some policy

--- a/neuro_san/http_sidecar/interfaces/agent_authorizer.py
+++ b/neuro_san/http_sidecar/interfaces/agent_authorizer.py
@@ -1,0 +1,28 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+"""
+See class comment for details
+"""
+
+class AgentAuthorizer:
+    """
+    Abstract interface implementing some policy
+    of allowing to route incoming requests to an agent.
+    """
+
+    def allow(self, agent_name) -> bool:
+        """
+        :param agent_name: name of an agent
+        :return: True if routing requests is allowed for this agent;
+                 False otherwise
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This PR switches Http server for agents requests to dynamic routing.
That means that our separate policy (very straightforward for now)
will decide which agent names are recognized as valid to pass API requests through.

Tested by running the usual "chicken", "music_nerd" and "hello_world" tests with all agents enabled,
and then trying "hello_world" test with internal debug thread flipping enable/disable flag for this agent repeatedly
without restarting the server.

