### PR TITLE
UN-3115 success_ratio in data-driven agent tests

### DIFF
--- a/tests/framework/driver/assert_capture.py
+++ b/tests/framework/driver/assert_capture.py
@@ -1,0 +1,200 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import List
+
+from tests.framework.interfaces.assert_forwarder import AssertForwarder
+
+
+class AssertCapture(AssertForwarder):
+    """
+    AssertForwarder implementation that wraps another AssertForwarder and
+    captures any exceptions thrown from it.
+    """
+
+    def __init__(self, basis: AssertForwarder):
+        """
+        Constructor
+
+        :param basis: AssertForwarder
+        """
+        self.basis: AssertForwarder = basis
+        self.asserts: List[AssertionError] = []
+
+    def get_asserts(self) -> List[AssertionError]:
+        """
+        :return: The list of asserts captured from the basis
+        """
+        return self.asserts
+
+    # pylint: disable=invalid-name
+    def assertEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is equal to the second
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertEqual(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertNotEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is not equal to the second
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertNotEqual(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertTrue(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is true
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertTrue(expr, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertFalse(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is false
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertFalse(expr, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertIs(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first and second are the same object
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertIs(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertIsNot(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first and second are not the same object
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertIsNot(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertIsNone(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is None
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertIsNone(expr, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertIsNotNone(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is not None
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertIsNotNone(expr, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertIn(self, member: Any, container: Any, msg: str = None):
+        """
+        Assert that the member is in the container
+
+        :param member: Member comparison element
+        :param container: Container comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertIn(member, container, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertNotIn(self, member: Any, container: Any, msg: str = None):
+        """
+        Assert that the member is not in the container
+
+        :param member: Member comparison element
+        :param container: Container comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertNotIn(member, container, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertIsInstance(self, obj: Any, cls: Any, msg: str = None):
+        """
+        Assert that the obj is an instance of the cls
+
+        :param obj: object instance comparison element
+        :param cls: Class comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertIsInstance(obj, cls, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertNotIsInstance(self, obj: Any, cls: Any, msg: str = None):
+        """
+        Assert that the obj is not an instance of the cls
+
+        :param obj: object instance comparison element
+        :param cls: Class comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertNotIsInstance(obj, cls, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)

--- a/tests/framework/driver/data_driven_agent_test_driver.py
+++ b/tests/framework/driver/data_driven_agent_test_driver.py
@@ -27,6 +27,7 @@ from neuro_san.internals.utils.file_of_class import FileOfClass
 from neuro_san.message_processing.basic_message_processor import BasicMessageProcessor
 from neuro_san.session.direct_agent_session import DirectAgentSession
 
+from tests.framework.driver.assert_capture import AssertCapture
 from tests.framework.evaluators.agent_evaluator_factory import AgentEvaluatorFactory
 from tests.framework.interfaces.agent_evaluator import AgentEvaluator
 from tests.framework.interfaces.assert_forwarder import AssertForwarder
@@ -47,7 +48,7 @@ class DataDrivenAgentTestDriver:
                         back into the test system.
         :param fixtures: Optional path to the fixtures root.
         """
-        self.asserts: AssertForwarder = asserts
+        self.asserts_basis: AssertForwarder = asserts
         self.fixtures: FileOfClass = fixtures
         if self.fixtures is None:
             self.fixtures = FileOfClass(__file__, path_to_basis="../../fixtures")
@@ -60,9 +61,69 @@ class DataDrivenAgentTestDriver:
         """
         test_case: Dict[str, Any] = self.parse_hocon_test_case(hocon_file)
 
+        agent: str = test_case.get("agent")
+        self.asserts_basis.assertIsNotNone(agent)
+
+        # Get the success ration
+        success_ratio: str = test_case.get("success_ratio", "1/1")
+        self.asserts_basis.assertIn("/", success_ratio)
+
+        # Find the integer components of the success ratio
+        success_split: List[str] = success_ratio.split("/")
+        num_need_success: int = int(success_split[0])
+        num_iterations: int = int(success_split[-1])
+
+        # Put some bounds on the number of iterations
+        num_iterations = max(1, num_iterations)
+        num_need_success = min(num_need_success, num_iterations)
+
+        # Capture asserts for each iteration
+        iteration_asserts: List[AssertCapture] = []
+
+        # Loop through each iteration, capturing any asserts.
+        num_successful: int = 0
+        for index in range(num_iterations):
+
+            _ = index
+
+            # Capture the asserts for this iteration and add it to the list for later
+            assert_capture = AssertCapture(self.asserts_basis)
+            iteration_asserts.append(assert_capture)
+
+            # Perform a single iteration of the test.
+            self.one_iteration(test_case, assert_capture)
+
+            # Update our counter if this iteration is successful
+            asserts: List[AssertionError] = assert_capture.get_asserts()
+            if len(asserts) == 0:
+                num_successful += 1
+
+        # Don't bother reporting any asserts if we have met our success ratio.
+        # Return early to pass this test.
+        if num_successful >= num_need_success:
+            return
+
+        # Find the first assert that fails and use it to fail this test
+        for assert_capture in iteration_asserts:
+            asserts: List[AssertionError] = assert_capture.get_asserts()
+            if len(asserts) > 0:
+                one_assert: AssertionError = asserts[0]
+                message: str = """
+{num_successful} of {num_iterations} iterations on agent {agent} were successful.
+Need at least {num_need_success} to consider {hocon_file} test to be successful.
+"""
+                raise AssertionError(message) from one_assert
+
+    def one_iteration(self, test_case: Dict[str, Any], asserts: AssertForwarder):
+        """
+        Perform a single iteration on the test case.
+
+        :param test_case: The dictionary describing the data-driven test case
+        :param asserts: The AssertForwarder to send asserts to.
+        """
+
         # Get the agent to use
         agent: str = test_case.get("agent")
-        self.asserts.assertIsNotNone(agent)
 
         # Get the connection type
         connections: Union[List[str], str] = test_case.get("connections")
@@ -72,13 +133,13 @@ class DataDrivenAgentTestDriver:
         elif isinstance(connections, str):
             # Make single strings into a list for consistent parsing
             connections = [connections]
-        self.asserts.assertIsInstance(connections, List)
-        self.asserts.assertTrue(len(connections) > 0)
+        asserts.assertIsInstance(connections, List)
+        asserts.assertTrue(len(connections) > 0)
 
         # Collect the interations to test for
         empty: List[Any] = []
         interactions: List[Dict[str, Any]] = test_case.get("interactions", empty)
-        self.asserts.assertTrue(len(interactions) > 0)
+        asserts.assertTrue(len(interactions) > 0)
 
         # Collect other session information
         use_direct: bool = test_case.get("use_direct", False)
@@ -94,7 +155,7 @@ class DataDrivenAgentTestDriver:
             for interaction in interactions:
                 if isinstance(session, DirectAgentSession):
                     session.reset()
-                chat_context = self.interact(agent, session, interaction, chat_context)
+                chat_context = self.interact(agent, session, interaction, chat_context, asserts)
 
     def parse_hocon_test_case(self, hocon_file: str) -> Dict[str, Any]:
         """
@@ -107,14 +168,16 @@ class DataDrivenAgentTestDriver:
         test_case: Dict[str, Any] = hocon.restore(file_reference=test_path)
         return test_case
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments
     def interact(self, agent: str, session: AgentSession, interaction: Dict[str, Any],
-                 chat_context: Dict[str, Any]) -> Dict[str, Any]:
+                 chat_context: Dict[str, Any], asserts: AssertForwarder) -> Dict[str, Any]:
         """
         Interact with an agent and evaluate its output
 
         :param session: The AgentSession to work with
         :param interaction: The interaction dictionary to base evalaution off of.
+        :param chat_context: The chat context to use with the interaction (if any)
+        :param asserts: The AssertForwarder to send asserts to.
         """
         _ = agent       # For now
         empty: Dict[str, Any] = {}
@@ -143,7 +206,7 @@ class DataDrivenAgentTestDriver:
         # Evaluate response
         response: Dict[str, Any] = interaction.get("response", empty)
         response_extractor = DictionaryExtractor(response)
-        self.test_response_keys(processor, response_extractor, self.TEST_KEYS)
+        self.test_response_keys(processor, response_extractor, self.TEST_KEYS, asserts)
 
         # See how we should continue the conversation
         return_chat_context: Dict[str, Any] = None
@@ -154,13 +217,15 @@ class DataDrivenAgentTestDriver:
 
     def test_response_keys(self, processor: BasicMessageProcessor,
                            response_extractor: DictionaryExtractor,
-                           keys: List[str]):
+                           keys: List[str],
+                           asserts: AssertForwarder):
         """
         Tests the given response keys
 
         :param processor: The BasicMessageProcessor instance to query results from.
         :param response_extractor: The DictionaryExtractor for the test structure from the test hocon file.
         :param keys: The response keys to test
+        :param asserts: The AssertForwarder to send asserts to.
         """
         deeper_test_keys: List[str] = []
 
@@ -180,11 +245,11 @@ class DataDrivenAgentTestDriver:
                 split: List[str] = test_key.split(".")
                 evaluator_type: str = split[-1]            # Last component of .-delimited key
                 verify_key: str = ".".join(split[:-1])      # All but last component of .-delimited key
-                evaluator: AgentEvaluator = AgentEvaluatorFactory.create_evaluator(self.asserts,
+                evaluator: AgentEvaluator = AgentEvaluatorFactory.create_evaluator(asserts,
                                                                                    evaluator_type)
                 if evaluator is not None:
                     evaluator.evaluate(processor, verify_key, test_key_value)
 
         # Recurse if there are further dictionary specs to dive into
         if len(deeper_test_keys) > 0:
-            self.test_response_keys(processor, response_extractor, deeper_test_keys)
+            self.test_response_keys(processor, response_extractor, deeper_test_keys, asserts)

--- a/tests/framework/driver/data_driven_agent_test_driver.py
+++ b/tests/framework/driver/data_driven_agent_test_driver.py
@@ -108,7 +108,7 @@ class DataDrivenAgentTestDriver:
             asserts: List[AssertionError] = assert_capture.get_asserts()
             if len(asserts) > 0:
                 one_assert: AssertionError = asserts[0]
-                message: str = """
+                message: str = f"""
 {num_successful} of {num_iterations} iterations on agent {agent} were successful.
 Need at least {num_need_success} to consider {hocon_file} test to be successful.
 """

--- a/tests/framework/driver/data_driven_agent_test_driver.py
+++ b/tests/framework/driver/data_driven_agent_test_driver.py
@@ -95,8 +95,14 @@ class DataDrivenAgentTestDriver:
 
             # Update our counter if this iteration is successful
             asserts: List[AssertionError] = assert_capture.get_asserts()
-            if len(asserts) == 0:
-                num_successful += 1
+            if len(asserts) > 0:
+                # Not successful
+                continue
+
+            num_successful += 1
+            if num_successful == num_need_success:
+                # Don't do more tests than we actually need to
+                break
 
         # Don't bother reporting any asserts if we have met our success ratio.
         # Return early to pass this test.

--- a/tests/framework/evaluators/gist_agent_evaluator.py
+++ b/tests/framework/evaluators/gist_agent_evaluator.py
@@ -35,10 +35,23 @@ class GistAgentEvaluator(AbstractAgentEvaluator):
         pass_fail: bool = self.ask_llm(acceptance_criteria=str(verify_value),
                                        text_sample=str(test_value))
 
+        did_str: str = "didn't"
         if self.negate:
-            self.asserts.assertFalse(pass_fail)
+            did_str = "did"
+
+        message: str = f"""
+text_sample unexpectedly {did_str} match acceptance criteria.
+
+text_sample:
+{test_value}
+
+acceptance_criteria:
+{verify_value}
+"""
+        if self.negate:
+            self.asserts.assertFalse(pass_fail, msg=message)
         else:
-            self.asserts.assertTrue(pass_fail)
+            self.asserts.assertTrue(pass_fail, msg=message)
 
     def ask_llm(self, acceptance_criteria: str, text_sample: str) -> bool:
         """

--- a/tests/framework/evaluators/gist_agent_evaluator.py
+++ b/tests/framework/evaluators/gist_agent_evaluator.py
@@ -35,6 +35,11 @@ class GistAgentEvaluator(AbstractAgentEvaluator):
         pass_fail: bool = self.ask_llm(acceptance_criteria=str(verify_value),
                                        text_sample=str(test_value))
 
+        # Make the exception messaging agree with the sense of the negation.
+        # That is: When we are playing it straight (no negation), the assertion
+        # fails because the text sample didn't match the acceptance criteria
+        # and that failure is unexpected.  When the negation is in place,
+        # it is unexpected that it actually *did* match the acceptance criteria.
         did_str: str = "didn't"
         if self.negate:
             did_str = "did"


### PR DESCRIPTION
Tests can now specify a top level "success_ratio".  This is of the form "A/B" where B iterations are performed and at least A iterations need to pass in order to be successful. By default this ratio is "1/1".

Eventually this ratio can be used in a development scenario where B iterations are performed and we collect and analyze the reasons why the test failed however many times it did. That is for a later PR, but on its own this allows for the imperfections inherent in LLM-based agents to not necessarily fail when they are Good Enough for testing purposes.
