### PR TITLE
Correct typo in integration test config file

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,7 @@ jobs:
 
 
       - name: Run pytest (excluding integration tests)
-        run: - pytest -s --verbose -m "integration" --timer-top-n 100
+        run: pytest -s --verbose -m "integration" --timer-top-n 100
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 


### PR DESCRIPTION
We moved from codefresh to github actions, the integration test is the last piece to go in. This PR fixes a typo that prevents the test from running.