### PR TITLE
Enable manual triggering for integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,7 @@ name: Integration
 on:
   schedule:
     - cron: '0 12 * * *'  # 12:00 PM UTC = 4:00 AM PT (standard)
+  workflow_dispatch:      # enables manual triggering
 
 jobs:
   test:


### PR DESCRIPTION
This PR puts in the necessary scheduling directive to allow us to manually trigger the integration test when needed.