### PR TITLE
UN-2778 Dynamic agent endpoints

### DIFF
--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -141,13 +141,17 @@ class BaseRequestHandler(RequestHandler):
             data: Dict[str, Any] = {}
             grpc_session: ConciergeSession = self.get_concierge_grpc_session(metadata)
             agents_dict: Dict[str, Any] = grpc_session.list(data)
-            self.agents_updater.update_agents(agents_dict)
+            agents_list = agents_dict.get("agents", [])
+            agents_names: List[str] = []
+            for agent_dict in agents_list:
+                agents_names.append(agent_dict["agent_name"])
+
+            print(f">>>>>>>>>>>> AGENTS: {agents_names}")
+
+            self.agents_updater.update_agents(agents_names)
             return True
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.process_exception(exc)
-            return False
-        finally:
-            await self.flush()
             return False
 
     def extract_grpc_error_info(self, exc: grpc.aio.AioRpcError) -> Tuple[int, str, str]:

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -27,6 +27,7 @@ from tornado.web import RequestHandler
 
 from neuro_san.http_sidecar.logging.http_logger import HttpLogger
 from neuro_san.http_sidecar.interfaces.agent_authorizer import AgentAuthorizer
+from neuro_san.http_sidecar.interfaces.agents_updater import AgentsUpdater
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
 from neuro_san.interfaces.concierge_session import ConciergeSession
 from neuro_san.session.async_grpc_service_agent_session import AsyncGrpcServiceAgentSession
@@ -55,6 +56,7 @@ class BaseRequestHandler(RequestHandler):
     # pylint: disable=attribute-defined-outside-init
     def initialize(self,
                    agent_policy: AgentAuthorizer,
+                   agents_updater: AgentsUpdater,
                    port: int,
                    forwarded_request_metadata: List[str],
                    openapi_service_spec_path: str):
@@ -62,12 +64,15 @@ class BaseRequestHandler(RequestHandler):
         This method is called by Tornado framework to allow
         injecting service-specific data into local handler context.
         :param agent_policy: abstract policy for agent requests
+        :param agents_updater: abstract policy for updating
+                               collection of agents being served
         :param port: gRPC service port.
         :param forwarded_request_metadata: request metadata to forward.
         :param openapi_service_spec_path: file path to OpenAPI service spec.
         """
 
         self.agent_policy = agent_policy
+        self.agents_updater = agents_updater
         self.port: int = port
         self.forwarded_request_metadata: List[str] = forwarded_request_metadata
         self.openapi_service_spec_path: str = openapi_service_spec_path
@@ -123,6 +128,27 @@ class BaseRequestHandler(RequestHandler):
                 port=self.port,
                 metadata=metadata)
         return grpc_session
+
+    async def update_agents(self, metadata: Dict[str, Any]) -> bool:
+        """
+        Update internal agents table by executing request
+        to underlying gRPC service.
+        :param metadata: metadata for request from caller context.
+        :return: True if update was successful
+                 False otherwise
+        """
+        try:
+            data: Dict[str, Any] = {}
+            grpc_session: ConciergeSession = self.get_concierge_grpc_session(metadata)
+            agents_dict: Dict[str, Any] = grpc_session.list(data)
+            self.agents_updater.update_agents(agents_dict)
+            return True
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.process_exception(exc)
+            return False
+        finally:
+            await self.flush()
+            return False
 
     def extract_grpc_error_info(self, exc: grpc.aio.AioRpcError) -> Tuple[int, str, str]:
         """

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -54,6 +54,8 @@ class BaseRequestHandler(RequestHandler):
     request_id: int = 0
 
     # pylint: disable=attribute-defined-outside-init
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
     def initialize(self,
                    agent_policy: AgentAuthorizer,
                    agents_updater: AgentsUpdater,

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -147,9 +147,6 @@ class BaseRequestHandler(RequestHandler):
             agents_names: List[str] = []
             for agent_dict in agents_list:
                 agents_names.append(agent_dict["agent_name"])
-
-            print(f">>>>>>>>>>>> AGENTS: {agents_names}")
-
             self.agents_updater.update_agents(agents_names)
             return True
         except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/neuro_san/http_sidecar/handlers/connectivity_handler.py
+++ b/neuro_san/http_sidecar/handlers/connectivity_handler.py
@@ -27,13 +27,17 @@ class ConnectivityHandler(BaseRequestHandler):
         """
         Implementation of GET request handler for "connectivity" API call.
         """
+        metadata: Dict[str, Any] = self.get_metadata()
+        update_done: bool = await self.update_agents(metadata)
+        if not update_done:
+            return
+
         if not self.agent_policy.allow(agent_name):
             self.set_status(404)
             self.logger.error({}, "error: Invalid request path %s", self.request.path)
             await self.flush()
             return
 
-        metadata: Dict[str, Any] = self.get_metadata()
         self.logger.info(metadata, "Start GET %s/connectivity", agent_name)
         try:
             data: Dict[str, Any] = {}

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -27,13 +27,17 @@ class FunctionHandler(BaseRequestHandler):
         """
         Implementation of GET request handler for "function" API call.
         """
+        metadata: Dict[str, Any] = self.get_metadata()
+        update_done: bool = await self.update_agents(metadata)
+        if not update_done:
+            return
+
         if not self.agent_policy.allow(agent_name):
             self.set_status(404)
             self.logger.error({}, "error: Invalid request path %s", self.request.path)
             await self.flush()
             return
 
-        metadata: Dict[str, Any] = self.get_metadata()
         self.logger.info(metadata, "Start GET %s/function", agent_name)
         try:
             data: Dict[str, Any] = {}

--- a/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
+++ b/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
@@ -59,13 +59,17 @@ class StreamingChatHandler(BaseRequestHandler):
         """
         Implementation of POST request handler for streaming chat API call.
         """
+        metadata: Dict[str, Any] = self.get_metadata()
+        update_done: bool = await self.update_agents(metadata)
+        if not update_done:
+            return
+
         if not self.agent_policy.allow(agent_name):
             self.set_status(404)
             self.logger.error({}, "error: Invalid request path %s", self.request.path)
             await self.flush()
             return
 
-        metadata: Dict[str, Any] = self.get_metadata()
         self.logger.info(metadata, "Start POST %s/streaming_chat", agent_name)
         sent_out = 0
         try:

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -109,7 +109,7 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
                 self.allowed_agents[agent_name] = True
             # All other agents are disabled:
             for agent_name, _ in self.allowed_agents.items():
-                if not agent_name in agents:
+                if agent_name not in agents:
                     self.allowed_agents[agent_name] = False
 
     def build_request_data(self) -> Dict[str, Any]:

--- a/neuro_san/http_sidecar/interfaces/agents_updater.py
+++ b/neuro_san/http_sidecar/interfaces/agents_updater.py
@@ -12,6 +12,8 @@
 """
 See class comment for details
 """
+from typing import Any
+from typing import List
 
 
 class AgentsUpdater:
@@ -20,10 +22,9 @@ class AgentsUpdater:
     being served.
     """
 
-    def update_agents(self, agents: Dict[str, Any]):
+    def update_agents(self, agents: List[str]):
         """
-        :param agents: dictionary of agents which should be served currently.
-            dictionary keys are "agent_name"
+        :param agents: list of agents names which should be served currently.
         :return: nothing
         """
         raise NotImplementedError

--- a/neuro_san/http_sidecar/interfaces/agents_updater.py
+++ b/neuro_san/http_sidecar/interfaces/agents_updater.py
@@ -12,7 +12,6 @@
 """
 See class comment for details
 """
-from typing import Any
 from typing import List
 
 

--- a/neuro_san/http_sidecar/interfaces/agents_updater.py
+++ b/neuro_san/http_sidecar/interfaces/agents_updater.py
@@ -1,0 +1,29 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+"""
+See class comment for details
+"""
+
+
+class AgentsUpdater:
+    """
+    Abstract interface for updating current collection of agents
+    being served.
+    """
+
+    def update_agents(self, agents: Dict[str, Any]):
+        """
+        :param agents: dictionary of agents which should be served currently.
+            dictionary keys are "agent_name"
+        :return: nothing
+        """
+        raise NotImplementedError

--- a/neuro_san/internals/interfaces/agent_state_listener.py
+++ b/neuro_san/internals/interfaces/agent_state_listener.py
@@ -1,0 +1,34 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from neuro_san.internals.interfaces.agent_tool_factory_provider import AgentToolFactoryProvider
+
+
+class AgentStateListener:
+    """
+    Abstract interface for publishing agent state changes -
+    when an agent is being added or removed from the service.
+    """
+
+    def agent_added(self, agent_name: str):
+        """
+        Agent is being added to the service.
+        :param agent_name: name of an agent
+        """
+        raise NotImplementedError
+
+    def agent_removed(self, agent_name: str):
+        """
+        Agent is being removed from the service.
+        :param agent_name: name of an agent
+        """
+        raise NotImplementedError

--- a/neuro_san/internals/interfaces/agent_state_listener.py
+++ b/neuro_san/internals/interfaces/agent_state_listener.py
@@ -10,9 +10,6 @@
 #
 # END COPYRIGHT
 
-from neuro_san.internals.interfaces.agent_tool_factory_provider import AgentToolFactoryProvider
-
-
 class AgentStateListener:
     """
     Abstract interface for publishing agent state changes -

--- a/neuro_san/internals/interfaces/agent_state_listener.py
+++ b/neuro_san/internals/interfaces/agent_state_listener.py
@@ -23,6 +23,13 @@ class AgentStateListener:
         """
         raise NotImplementedError
 
+    def agent_modified(self, agent_name: str):
+        """
+        Existing agent has been modified in service scope.
+        :param agent_name: name of an agent
+        """
+        raise NotImplementedError
+
     def agent_removed(self, agent_name: str):
         """
         Agent is being removed from the service.

--- a/neuro_san/internals/tool_factories/service_tool_factory_provider.py
+++ b/neuro_san/internals/tool_factories/service_tool_factory_provider.py
@@ -80,11 +80,12 @@ class ServiceToolFactoryProvider(ToolFactoryProvider):
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:
-            listener.agent_added(agent_name)
-        if is_new:
-            self.logger.info("ADDED tool registry for agent %s", agent_name)
-        else:
-            self.logger.info("REPLACED tool registry for agent %s", agent_name)
+            if is_new:
+                listener.agent_added(agent_name)
+                self.logger.info("ADDED tool registry for agent %s", agent_name)
+            else:
+                listener.agent_modified(agent_name)
+                self.logger.info("REPLACED tool registry for agent %s", agent_name)
 
     def remove_agent_tool_registry(self, agent_name: str):
         """

--- a/neuro_san/internals/tool_factories/service_tool_factory_provider.py
+++ b/neuro_san/internals/tool_factories/service_tool_factory_provider.py
@@ -11,7 +11,6 @@
 
 import logging
 import threading
-from typing import Any
 from typing import Dict
 from typing import List
 
@@ -19,7 +18,6 @@ from neuro_san.internals.interfaces.tool_factory_provider import ToolFactoryProv
 from neuro_san.internals.interfaces.agent_state_listener import AgentStateListener
 from neuro_san.internals.run_context.interfaces.agent_tool_factory import AgentToolFactory
 from neuro_san.internals.tool_factories.single_agent_tool_factory_provider import SingleAgentToolFactoryProvider
-from neuro_san.internals.graph.persistence.agent_tool_registry_restorer import AgentToolRegistryRestorer
 
 
 class ServiceToolFactoryProvider(ToolFactoryProvider):

--- a/neuro_san/internals/tool_factories/service_tool_factory_provider.py
+++ b/neuro_san/internals/tool_factories/service_tool_factory_provider.py
@@ -61,17 +61,11 @@ class ServiceToolFactoryProvider(ToolFactoryProvider):
         if listener in self.listeners:
             self.listeners.remove(listener)
 
-    def build_agent_tool_registry(self, agent_name: str, config: Dict[str, Any]):
-        """
-        Build agent tool registry from its configuration dictionary
-        and register it for given agent name.
-        """
-        registry: AgentToolFactory = AgentToolRegistryRestorer().restore_from_config(agent_name, config)
-        self.add_agent_tool_registry(agent_name, registry)
-
     def add_agent_tool_registry(self, agent_name: str, registry: AgentToolFactory):
         """
-        Register existing agent tool registry
+        This method is a single point of entry in the service
+        where we register a new "agent name + AgentToolFactory" pair in the service scope
+        or notify the service that for existing agent its AgentToolFactory has been modified.
         """
         is_new: bool = False
         with self.lock:
@@ -89,7 +83,8 @@ class ServiceToolFactoryProvider(ToolFactoryProvider):
 
     def remove_agent_tool_registry(self, agent_name: str):
         """
-        Remove agent tool registry from the table
+        Remove agent name and its AgentToolFactory from service scope,
+        so that agent becomes unavailable on our server.
         """
         with self.lock:
             self.agents_table.pop(agent_name, None)

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -128,6 +128,15 @@ class AgentServer:
         service_router: DynamicAgentRouter = DynamicAgentRouter().get_instance()
         service_router.add_service(agent_service_name, agent_rpc_handlers)
 
+    def agent_modified(self, agent_name: str):
+        """
+        Agent is being modified in the service scope.
+        :param agent_name: name of an agent
+        """
+        # Endpoints configuration has not changed,
+        # so nothing to do here, actually.
+        return
+
     def agent_removed(self, agent_name: str):
         """
         Agent is being removed from the service.

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -142,16 +142,17 @@ class AgentServer:
         Start serving gRPC requests
         """
         values = agent_pb2.DESCRIPTOR.services_by_name.values()
-        self.server_lifetime = ServerLifetime(self.server_name,
-                                         self.server_name_for_logs,
-                                         self.port, self.logger,
-                                         request_limit=self.request_limit,
-                                         max_workers=self.max_concurrent_requests,
-                                         max_concurrent_rpcs=None,
-                                         # Used for health checking. Probably needs agent-specific love.
-                                         protocol_services_by_name_values=values,
-                                         loop_sleep_seconds=5.0,
-                                         server_loop_callbacks=self.server_loop_callbacks)
+        self.server_lifetime = ServerLifetime(
+            self.server_name,
+            self.server_name_for_logs,
+            self.port, self.logger,
+            request_limit=self.request_limit,
+            max_workers=self.max_concurrent_requests,
+            max_concurrent_rpcs=None,
+            # Used for health checking. Probably needs agent-specific love.
+            protocol_services_by_name_values=values,
+            loop_sleep_seconds=5.0,
+            server_loop_callbacks=self.server_loop_callbacks)
 
         server = self.server_lifetime.create_server()
 

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -176,20 +176,6 @@ class AgentServer:
 
         self.setup_tool_factory_provider()
 
-        # service_router: DynamicAgentRouter = DynamicAgentRouter().get_instance()
-        # agent_names: List[str] = tool_factory_provider.get_agent_names()
-        # for agent_name in agent_names:
-        #     service = AgentService(server_lifetime, security_cfg,
-        #                            agent_name,
-        #                            tool_factory_provider.get_agent_tool_factory_provider(agent_name),
-        #                            self.server_logging)
-        #     self.services.append(service)
-        #
-        #     servicer_to_server = AgentServicerToServer(service)
-        #     agent_rpc_handlers = servicer_to_server.build_rpc_handlers()
-        #     agent_service_name: str = AgentServiceStub.prepare_service_name(agent_name)
-        #     service_router.add_service(agent_service_name, agent_rpc_handlers)
-
         # Add DynamicAgentRouter instance as a generic RPC handler for our server:
         service_router: DynamicAgentRouter = DynamicAgentRouter().get_instance()
         server.add_generic_rpc_handlers((service_router,))

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -135,7 +135,7 @@ class AgentServer:
         """
         # Endpoints configuration has not changed,
         # so nothing to do here, actually.
-        return
+        _ = agent_name
 
     def agent_removed(self, agent_name: str):
         """

--- a/neuro_san/service/agent_servicer_to_server.py
+++ b/neuro_san/service/agent_servicer_to_server.py
@@ -11,14 +11,10 @@
 # END COPYRIGHT
 from typing import Dict
 
-from grpc import GenericRpcHandler
 from grpc import RpcMethodHandler
-from grpc import Server
-from grpc import method_handlers_generic_handler
 from grpc import unary_stream_rpc_method_handler
 from grpc import unary_unary_rpc_method_handler
 
-from neuro_san.session.agent_service_stub import AgentServiceStub
 import neuro_san.api.grpc.agent_pb2 as agent__pb2
 from neuro_san.api.grpc.agent_pb2_grpc import AgentServiceServicer
 

--- a/neuro_san/service/agent_servicer_to_server.py
+++ b/neuro_san/service/agent_servicer_to_server.py
@@ -30,20 +30,17 @@ class AgentServicerToServer:
     by the same server with a simple addition of an agent name in the gRPC path.
     """
 
-    def __init__(self, servicer: AgentServiceServicer,
-                 agent_name: str = ""):
+    def __init__(self, servicer: AgentServiceServicer):
         """
         Constructor
         """
         self.servicer: AgentServiceServicer = servicer
-        self.agent_name: str = agent_name
 
-    def add_rpc_handlers(self, server: Server):
+    def build_rpc_handlers(self):
         """
-        Adds the RpcMethodHandlers to the server
-        :param server: The grpc.Server to which method handlers should be added
+        Constructs a table of RpcMethodHandlers
+        to be used for an agent service
         """
-
         # One entry for each grpc method defined in the agent handling protobuf
         # Note that all methods (as of 8/27/2024) are unary_unary.
         # (Watch generated _grpc.py for changes).
@@ -65,10 +62,4 @@ class AgentServicerToServer:
                     response_serializer=agent__pb2.ChatResponse.SerializeToString,
             ),
         }
-
-        # Prepare the service name on a per-agent basis
-        service_name: str = AgentServiceStub.prepare_service_name(self.agent_name)
-
-        generic_handler: GenericRpcHandler = method_handlers_generic_handler(service_name,
-                                                                             rpc_method_handlers)
-        server.add_generic_rpc_handlers((generic_handler,))
+        return rpc_method_handlers

--- a/neuro_san/service/dynamic_agent_router.py
+++ b/neuro_san/service/dynamic_agent_router.py
@@ -13,11 +13,12 @@
 See comments in class description
 """
 
-import grpc
 import logging
 from typing import Any
 from typing import Dict
 from threading import Lock
+import grpc
+
 
 class DynamicAgentRouter(grpc.GenericRpcHandler):
     """

--- a/neuro_san/service/dynamic_agent_router.py
+++ b/neuro_san/service/dynamic_agent_router.py
@@ -39,15 +39,6 @@ class DynamicAgentRouter(grpc.GenericRpcHandler):
         self.table_lock: Lock = Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    @classmethod
-    def get_instance(cls):
-        """
-        Get singleton instance of DynamicAgentRouter
-        """
-        if DynamicAgentRouter.instance is None:
-            DynamicAgentRouter.instance = DynamicAgentRouter()
-        return DynamicAgentRouter.instance
-
     def add_service(self, service_name: str, handlers: Dict[str, Any]):
         """
         Add service with its API handlers to this router.
@@ -84,4 +75,6 @@ class DynamicAgentRouter(grpc.GenericRpcHandler):
                 return method_handlers.get(method_name, None)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.logger.error("Failed to execute %s - %s", full_method, str(exc))
-        return None  # Request not handled
+        # Request not handled, in this case gRPC stack will raise UNIMPLEMENTED exception
+        # and http server will return error code 500 with details: "Method not found!"
+        return None

--- a/neuro_san/service/dynamic_agent_router.py
+++ b/neuro_san/service/dynamic_agent_router.py
@@ -1,0 +1,86 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+"""
+See comments in class description
+"""
+
+import grpc
+import logging
+from typing import Any
+from typing import Dict
+from threading import Lock
+
+class DynamicAgentRouter(grpc.GenericRpcHandler):
+    """
+    Class maintains a dynamic map of gRPC services exposed by a server.
+    Each gRPC service represents an agent available to clients.
+    Instance of this class is also a generic gRPC handler,
+    routing incoming gRPC request to appropriate API method handler
+    depending on service name.
+    """
+
+    instance = None
+
+    def __init__(self):
+        """
+        Constructor.
+        """
+        self.agents_table: Dict[str, Any] = {}
+        self.table_lock: Lock = Lock()
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    @classmethod
+    def get_instance(cls):
+        """
+        Get singleton instance of DynamicAgentRouter
+        """
+        if DynamicAgentRouter.instance is None:
+            DynamicAgentRouter.instance = DynamicAgentRouter()
+        return DynamicAgentRouter.instance
+
+    def add_service(self, service_name: str, handlers: Dict[str, Any]):
+        """
+        Add service with its API handlers to this router.
+        :param service_name: gRPC-formatted service name;
+        :param handlers: table of API handlers to register for this service.
+        """
+        with self.table_lock:
+            self.agents_table[service_name] = handlers
+        self.logger.info("Added service handlers for %s", service_name)
+
+    def remove_service(self, service_name: str):
+        """
+        Remove service from this router.
+        :param service_name: gRPC-formatted service name;
+        """
+        with self.table_lock:
+            self.agents_table.pop(service_name, None)
+        self.logger.info("Removed service handlers for %s", service_name)
+
+    def service(self, handler_call_details: grpc.HandlerCallDetails):
+        """
+        Service incoming gRPC request.
+        :param handler_call_details: gRPC incoming call details.
+        :return: gRPC method handler for this call. This handler will be invoked
+            elsewhere by gRPC machinery.
+        """
+        full_method: str = "unknown"
+        try:
+            full_method = handler_call_details.method  # e.g. "/my.Service/SomeMethod"
+            _, service_name, method_name = full_method.split("/", 2)
+            with self.table_lock:
+                method_handlers = self.agents_table.get(service_name, None)
+            if method_handlers:
+                return method_handlers.get(method_name, None)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.logger.error("Failed to execute %s - %s", full_method, str(exc))
+        return None  # Request not handled

--- a/neuro_san/session/direct_concierge_session.py
+++ b/neuro_san/session/direct_concierge_session.py
@@ -12,10 +12,10 @@
 
 from typing import Any
 from typing import Dict
+from typing import List
 
 from neuro_san.interfaces.concierge_session import ConciergeSession
-from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
-from neuro_san.internals.graph.registry.agent_tool_registry import AgentToolRegistry
+from neuro_san.internals.tool_factories.service_tool_factory_provider import ServiceToolFactoryProvider
 
 
 class DirectConciergeSession(ConciergeSession):
@@ -51,10 +51,10 @@ class DirectConciergeSession(ConciergeSession):
                     protobuf structure. Has the following keys:
                 "agents" - the sequence of dictionaries describing available agents
         """
-        manifest_restorer = RegistryManifestRestorer()
-        manifest_registries: Dict[str, AgentToolRegistry] = manifest_restorer.restore()
-
-        agents_list = []
-        for agent_name, _ in manifest_registries.items():
+        tool_factory_provider: ServiceToolFactoryProvider = \
+            ServiceToolFactoryProvider.get_instance()
+        agents_names: List[str] = tool_factory_provider.get_agent_names()
+        agents_list: List[Dict[str, Any]] = []
+        for agent_name in agents_names:
             agents_list.append({"agent_name": agent_name, "description": ""})
         return {"agents": agents_list}


### PR DESCRIPTION
This PR implements dynamic collection of agents supported by running neuro-san server.
Overall architecture looks like this:

- singleton instance of ServiceToolFactoryProvider keeps a dynamic table of agent names mapped to their AgentToolFactory instances. This is our "source of truth" representing actual state of the service;
- ServiceToolFactoryProvider provides methods to add and remove agent+AgentToolFactory pairs to/from the state;
- singleton instance of DynamicAgentRouter works as universal gRPC requests handler for any agent+method pair we may throw at the server. Again, it keeps an internal dynamic table of agent names which are allowed for serving requests;
- there are state listeners which can be registered with ServiceToolFactoryProvider to be notified about state changes, and instance of AgentServer works as such a listener (the only one for now);
- on state change notification, AgentServer calls DynamicAgentRouter methods to update its own routing table.
- for Http server, situation is different, because it runs in separate process space and cannot watch  ServiceToolFactoryProvider directly. So it queries host gRPC endpoint before executing any agent-related request for a set of available agents and routs request only if agent qualifies as "available". There are obviously performance implications for this way of doing things, but for streaming chat they are negligible, and simple requests are fast anyway.

Tested: by putting together simple file directory watchdog, so that agent.hocon files being added or removed there
result in compiled AgentToolFactory instances being added or removed to/from our ServiceToolFactoryProvider.
Service endpoints are then checked manually to be working or not working, both on gRPC and http APIs.
