### PR TITLE
UN-3116 First stab at agent failure assessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ From the top-level of this repo:
 
 Type in this input to the chat client:
 
-    I am travelling to a new planet and wish to send greetings to the orb.
+    From earth, I approach a new planet and wish to send a short 2-word greeting to the new orb.
 
 What should return is something like:
 
@@ -162,11 +162,10 @@ build.sh / run.sh the service like you did above to re-load the server,
 and interact with it via the agent_cli.py chat client, making sure
 you specify your agent correctly (per the hocon file stem).
 
-Note that the .hocon files in this repo are more spartan for testing and simple
-demonstration purposes.  For more full-featured demos, see the
-[neuro-san-demo repo.](https://github.com/leaf-ai/neuro-san-demos)
-
 ### More agent example files
+
+Note that the .hocon files in this repo are more spartan for testing and simple
+demonstration purposes.
 
 For more examples of agent networks, documentation and tutorials,
 see the [neuro-san-demos repo.](https://github.com/leaf-ai/neuro-san-demos)

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -210,14 +210,13 @@ Some suggestions:
         group = arg_parser.add_argument_group(title="Session Type",
                                               description="How will we connect to neuro-san?")
         group.add_argument("--connection", default="direct", type=str,
-                           choices=["grpc", "service", "direct", "http", "https"],
+                           choices=["grpc", "direct", "http", "https"],
                            help="""
 The type of connection to initiate. Choices are to connect to:
-    "grpc"      - an agent service via gRPC. (The default).  Needs host and port.
-    "service"   - compatibility synonym for 'grpc' above.
+    "grpc"      - an agent service via gRPC. Needs host and port.
     "http"      - an agent service via HTTP. Needs host and port.
     "https"     - an agent service via secure HTTP. Needs host and port.
-    "direct"    - a session via library.
+    "direct"    - a session via library. (The default).
 All choices require an agent name.
 """)
         group.add_argument("--grpc", dest="connection", action="store_const", const="grpc",

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -144,6 +144,7 @@ ENV AGENT_TOOL_PATH=${APP_SOURCE}/coded_tools
 # See https://docs.python.org/3/library/logging.config.html#dictionary-schema-details
 # as to how this file can be configured for your own needs.  Examples there are provided in YAML,
 # but these can be easily translated to JSON (which we prefer).
+# Another good resource: https://docs.python.org/3/howto/logging-cookbook.html
 ENV AGENT_SERVICE_LOG_JSON=${PACKAGE_DEPLOY}/logging.json
 
 # Threshold for logging.

--- a/neuro_san/registries/assess_failure.hocon
+++ b/neuro_san/registries/assess_failure.hocon
@@ -91,7 +91,7 @@ Follow these steps in your assessment:
     enough detail for future matches to be made against it.
 
 Return one and only one of the following:
-    * only the exact contents of the failure_mode you found in step (2) OR
+    * only the exact contents of the failure_mode you found in step (2) without any quotes OR
     * your newly prepared description of a newly discovered failure mode from step (3)
 Never add any embellishment or commentary to your answer.
 """,

--- a/neuro_san/registries/assess_failure.hocon
+++ b/neuro_san/registries/assess_failure.hocon
@@ -1,0 +1,101 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+{
+    "llm_config": {
+        "model_name": "gpt-4o",
+    },
+    "tools": [
+        # These tool definitions do not have to be in any particular order
+        # How they are linked and call each other is defined within their
+        # own specs.  This could be a graph, potentially even with cycles.
+
+        # This first guy is the "Front Man".  He is identified as such because
+        # he is the only one with no parameters in his function definition,
+        # and therefore he needs to talk to the outside world to get things rolling.
+        {
+            "name": "assess_failure",
+
+            "function": {
+
+                # When there are no function parameters to the front-man,
+                # its description acts as an initial prompt.
+
+                "description": """
+Knowing that a given text_sample fails against a given acceptance_criteria,
+this tool will attempt to classify just how the failure relates to which one
+of a list of previously known failure_modes.  Classifications can come from
+existing entries in the failure_modes list, or if nothing quite right exists
+in that list, this tool will propose a new category.
+""",
+                # This parameters section isn't strictly needed if the agent network
+                # is not expected to be called as a coded tool.
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "acceptance_criteria": {
+                            "type": "string",
+                            "description": """
+A description of what kind of content or meaning a text_sample would need to contain
+in order to constitute a passing value for the test.
+"""
+                        },
+                        "text_sample": {
+                            "type": "string",
+                            "description": "The sample of text known to fail against the acceptance_criteria"
+                        },
+                        "failure_modes": {
+                            "type": "array",
+                            "description": """
+An ordered list of strings describing modes of failure in which text_samples
+are known to fail against the given acceptance_criteria.
+"""
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": ["sample", "acceptance_criteria"]
+                }
+            },
+
+            "instructions": """
+You are an expert at categorizing descriptions of failure modes.
+
+You will be given these inputs:
+* an acceptance_criteria which describes what constitutes a passing evaluation for any sample of text.
+* a text_sample which is to be evaluated against the acceptance_criteria description.
+* a list of previously known failure_modes by which the text_sample is known to fail against the acceptance_criteria. It is possible this failure_modes list might be empty or be an incomplete listing.
+
+You will assess which failure_mode (if any) best corresponds to how the text_sample
+does not meet the acceptance_criteria.
+
+Follow these steps in your assessment:
+1.  Come to your own conclusion as to why the text_sample failed against the acceptance_criteria.
+    Should there be multiple points described in the acceptance_criteria, take care that any logical
+    descriptions containing OR or AND are upheld in your conclusion.
+2.  See if there is any one description in the failure_modes list that best matches your own assessment.
+    The description you select does not have to be an exact match to your own assessment,
+    but it should match the overall spirit of what failed down to a medium-grained level of detail
+    with respect to what was previously described.
+3.  It is possible that no existing description in the failure_modes quite matches your assessment.
+    If this is the case, prepare a description of a maximum of 2 sentences for a new failure mode with
+    enough detail for future matches to be made against it.
+
+Return one and only one of the following:
+    * only the exact contents of the failure_mode you found in step (2) OR
+    * your newly prepared description of a newly discovered failure mode from step (3)
+Never add any embellishment or commentary to your answer.
+""",
+            "tools": []
+        }
+    ]
+}

--- a/neuro_san/registries/gist.hocon
+++ b/neuro_san/registries/gist.hocon
@@ -30,15 +30,15 @@
                 # its description acts as an initial prompt.
 
                 "description": """
-Will return the single string "pass" if the text sample meets the given acceptance criterion
-or the single string "fail" if the text sample does not meet the given acceptance criterion.
+Will return the single string "pass" if the text sample meets the given acceptance criteria
+or the single string "fail" if the text sample does not meet the given acceptance criteria.
 """,
                 # This parameters section isn't strictly needed if the agent network
                 # is not expected to be called as a coded tool.
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "acceptance_criterion": {
+                        "acceptance_criteria": {
                             "type": "string",
                             "description": """
 A description of what kind of content or meaning a text_sample would need to contain
@@ -47,10 +47,10 @@ in order to constitute a passing value for the test.
                         },
                         "text_sample": {
                             "type": "string",
-                            "description": "The sample of text to match against the acceptance_criterion"
+                            "description": "The sample of text to match against the acceptance_criteria"
                         }
                     },
-                    "required": ["sample", "acceptance_criterion"]
+                    "required": ["sample", "acceptance_criteria"]
                 }
             },
 
@@ -58,18 +58,18 @@ in order to constitute a passing value for the test.
 You are an expert at evaluating text samples.
 
 You will be given two inputs:
-1. an acceptance_criterion which describes what constitutes a passing evaluation for any sample of text.
-2. a text_sample which is to be evaluated against the acceptance_criterion description.
+1. an acceptance_criteria which describes what constitutes a passing evaluation for any sample of text.
+2. a text_sample which is to be evaluated against the acceptance_criteria description.
 
 Evaluate the text_sample and come to a conclusion as to whether or not
-it meets what is described by the acceptance_criterion.
+it meets what is described by the acceptance_criteria.
 
-Should there be multiple points described in the acceptance_criterion, take care that any logical 
+Should there be multiple points described in the acceptance_criteria, take care that any logical 
 descriptions containing OR or AND are upheld in your conclusion.
 
 If you conclude that what is described by the acceptance_criteria is met by the contents of the text_sample, 
 output only the single word "pass", otherwise output only the single word "fail".
-Never add any embellishment or commentary to your answer other.
+Never add any embellishment or commentary to your answer.
 """,
             "tools": []
         }

--- a/neuro_san/registries/hello_world.hocon
+++ b/neuro_san/registries/hello_world.hocon
@@ -49,6 +49,7 @@ while never divulging the identity or nature of who has requested the announceme
 Then, after you have come up with what to say, you will always call a function
 to make the announcement as simple and concise as possible, yet eloquent.
 The synonymizer will need a name for the speech.
+Never add any embellishment or commentary to your answer.
 """,
             "tools": ["synonymizer"]
         },

--- a/neuro_san/registries/manifest.hocon
+++ b/neuro_san/registries/manifest.hocon
@@ -20,9 +20,8 @@
     "math_guy_passthrough.hocon": true,
     "music_nerd.hocon": true,
     "music_nerd_pro.hocon": true,
-    "gist.hocon": true,
 
-    # This one is an example of agnets calling tools that has no parameters.
+    # This one is an example of agents calling tools that has no parameters.
     "date_time.hocon": true,
 
     # These next 2 go together as an example for agents calling other agents.
@@ -36,6 +35,10 @@
     # This one is an example of agents calling global coded tools.
     # In other words, these coded tools can be used in any agent network.
     "website_rag.hocon": true,
+
+    # Agents having to do with test infrastructure
+    "gist.hocon": true,
+    "assess_failure.hocon": true,
 
     # STOP AND READ: YOU PROBABLY DON'T WANT TO ADD YOUR .hocon FILE HERE.
     #

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -58,6 +58,8 @@ class Assessor:
         # Initial output
         print(f"{self.args.test_hocon}:")
         print(f"{num_pass}/{num_total} attempts passed.")
+        if num_total == 1:
+            print("There was only one test attempt done. Consider setting 'success_ratio' on your test case hocon.")
         if num_pass == num_total:
             return
 

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -105,12 +105,14 @@ class Assessor:
 
         # Sort the modes of failure by how often they occurred,
         # with the most common appearing at the beginning of the list.
-        sorted_failures: List[str] = sorted(assessment.items(), key=lambda item: item[1], reverse=True)
+        # The item[1] in the lambda is the integer value representing the mode count of the failure.
+        # What is returned from sorted() is a list of key/value tuples which are reassembled
+        # back into a dictionary.
+        sorted_assessment: Dict[str, int] = dict(sorted(assessment.items(), key=lambda item: item[1], reverse=True))
 
         print(f"{num_fail}/{num_total} attempts failed.")
         print("Modes of failure:")
-        for failure_mode in sorted_failures:
-            mode_count: int = assessment.get(failure_mode)
+        for failure_mode, mode_count in sorted_assessment.items():
             percent: float = 100.0 * mode_count / num_fail
             print("")
             print(f"{mode_count}/{num_fail} failures ({percent:.2f}%):")

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -86,7 +86,7 @@ class Assessor:
         arg_parser.add_argument("--test_hocon", type=str,
                                 help="The test case .hocon file to use as a basis for assessment")
         arg_parser.add_argument("--assessor_agent", type=str, default=None,
-                                help="The assessor agent to use. A default of None implies use of assess_failure.hocon")
+                                help="The assessor agent to use. A default of None implies use of neuro-san stock assess_failure.hocon")
         arg_parser.add_argument("--connection", default="direct", type=str,
                                 choices=["grpc", "direct", "http", "https"],
                                 help="""

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -73,12 +73,12 @@ class Assessor:
                 mode_count[index] = mode_count[index] + 1
             else:
                 failure_modes.append(failure_mode)
-                mode_count[index] = 1
+                mode_count.append(1)
 
         # End ouput
         print(f"{len(fail)}/{num_total} attempts failed.")
         print("Modes of failure:")
-        for failure_mode, index in enumerate(failure_modes):
+        for index, failure_mode in enumerate(failure_modes):
             print("\n")
             print(f"{mode_count[index]}/{len(fail)}:")
             print(f"{failure_mode}")

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -165,9 +165,11 @@ The known failure_modes are:
                 and whose values are a list of failure dictionaries.
         :param num_total: The total number of attempts, including passing attempts.
         """
+        # Get a total failure count
         num_fail: int = 0
         for failure_list in assessment.values():
             num_fail += len(failure_list)
+        print(f"{num_fail}/{num_total} attempts failed.")
 
         # Sort the modes of failure by how often they occurred,
         # with the most common appearing at the beginning of the list.
@@ -177,7 +179,7 @@ The known failure_modes are:
         sorted_assessment: Dict[str, List[Dict[str, Any]]] = \
             dict(sorted(assessment.items(), key=lambda item: len(item[1]), reverse=True))
 
-        print(f"{num_fail}/{num_total} attempts failed.")
+        # Output specific modes of failure with example agent return values.
         print("Modes of failure:")
         for failure_mode, failure_list in sorted_assessment.items():
             mode_count: int = len(failure_list)

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -64,6 +64,17 @@ class Assessor:
         if num_pass == num_total:
             return
 
+        assessment: Dict[str, int] = self.assess_failures(fail)
+        self.output_failures(assessment, num_total)
+
+    def assess_failures(self, fail: List[Dict[str, Any]]) -> Dict[str, int]:
+        """
+        Assess the failures in a failure list
+
+        :param fail: A list of failure dictionaries from asserts.get_fail_dicts()
+        :return: A dictionary whose keys describe specific modes of failure,
+                and whose values are how many times that kind of failure occurred.
+        """
         failure_modes: List[str] = []
         mode_count: List[int] = []
         for one_failure in fail:
@@ -75,12 +86,34 @@ class Assessor:
                 failure_modes.append(failure_mode)
                 mode_count.append(1)
 
-        # End ouput
-        print(f"{len(fail)}/{num_total} attempts failed.")
-        print("Modes of failure:")
+        assessment: Dict[str, int] = {}
         for index, failure_mode in enumerate(failure_modes):
-            print("\n")
-            print(f"{mode_count[index]}/{len(fail)}:")
+            assessment[failure_mode] = mode_count[index]
+
+        return assessment
+
+    def output_failures(self, assessment: Dict[str, int], num_total: int):
+        """
+        Output the results of the failure assessment
+        :param assessment: A dictionary whose keys describe specific modes of failure,
+                and whose values are how many times that kind of failure occurred.
+        :param num_total: The total number of attempts, including passing attempts.
+        """
+        num_fail: int = 0
+        for value in assessment.values():
+            num_fail += value
+
+        # Sort the modes of failure by how often they occurred,
+        # with the most common appearing at the beginning of the list.
+        sorted_failures: List[str] = sorted(assessment.items(), key=lambda item: item[1], reverse=True)
+
+        print(f"{num_fail}/{num_total} attempts failed.")
+        print("Modes of failure:")
+        for failure_mode in sorted_failures:
+            mode_count: int = assessment.get(failure_mode)
+            percent: float = 100.0 * mode_count / num_fail
+            print("")
+            print(f"{mode_count}/{num_fail} failures ({percent:.2f}%):")
             print(f"{failure_mode}")
 
     def parse_args(self):

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -1,0 +1,58 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+import argparse
+
+from neuro_san.test.assessor.assessor_assert_forwarder import AssessorAssertForwarder
+from neuro_san.test.driver.data_drvien_agent_test_driver import DataDrivenAgentTestDriver
+
+
+class Assessor:
+    """
+    Command line tool for assessing an agent network's response
+    to an input test case.
+    """
+
+    def __init__(self):
+        """
+        Constructor
+        """
+        self.args = None
+
+    def main(self):
+        """
+        Main entry point for command line user interaction.
+        """
+        self.parse_args()
+        asserts = AssessorAssertForwarder()
+        driver = DataDrivenAgentTestDriver(asserts)
+        driver.one_test(self.args.test_hocon)
+
+    def parse_args(self):
+        """
+        Parse command line arguments into member variables
+        """
+        arg_parser = argparse.ArgumentParser()
+        self.add_args(arg_parser)
+        self.args = arg_parser.parse_args()
+
+    def add_args(self, arg_parser: argparse.ArgumentParser):
+        """
+        Adds arguments.  Allows subclasses a chance to add their own.
+        :param arg_parser: The argparse.ArgumentParser to add.
+        """
+        arg_parser.add_argument("--test_hocon", type=str,
+                                help="The test case .hocon file to use as a basis for assessment")
+
+
+if __name__ == '__main__':
+    Assessor().main()

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -9,6 +9,9 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+from typing import Any
+from typing import Dict
+from typing import List
 
 import argparse
 
@@ -32,10 +35,24 @@ class Assessor:
         """
         Main entry point for command line user interaction.
         """
+        # Parse command line arguments
         self.parse_args()
+
+        # Run the tests per the test case, collecting failure information in the AssertForwarder
         asserts = AssessorAssertForwarder()
         driver = DataDrivenAgentTestDriver(asserts)
         driver.one_test(self.args.test_hocon)
+
+        # Get raw failure information from AssertForwarder
+        num_total: int = asserts.get_num_total()
+        fail: List[Dict[str, Any]] = asserts.get_fail()
+        num_pass: int = num_total - len(fail)
+
+        # Initial output
+        print(f"{self.args.test_hocon}:")
+        print(f"{num_pass}/{num_total} attempts passed.")
+        if num_pass < num_total:
+            print(f"{len(fail)}/{num_total} attempts failed.")
 
     def parse_args(self):
         """

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -48,6 +48,8 @@ class Assessor:
         # Run the tests per the test case, collecting failure information in the AssertForwarder
         asserts = AssessorAssertForwarder()
         driver = DataDrivenAgentTestDriver(asserts)
+
+        print(f"Testing {self.args.test_hocon}:")
         driver.one_test(self.args.test_hocon)
 
         # Get raw failure information from AssertForwarder
@@ -56,7 +58,6 @@ class Assessor:
         num_pass: int = num_total - len(fail)
 
         # Initial output
-        print(f"{self.args.test_hocon}:")
         print(f"{num_pass}/{num_total} attempts passed.")
         if num_total == 1:
             print("There was only one test attempt done. Consider setting 'success_ratio' on your test case hocon.")

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -64,55 +64,9 @@ class Assessor:
         if num_pass == num_total:
             return
 
+        # Assess the failures by agent and output the results.
         assessment: Dict[str, List[Dict[str, Any]]] = self.assess_failures(fail)
         self.output_failures(assessment, num_total)
-
-    def assess_failures(self, fail: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
-        """
-        Assess the failures in a failure list
-
-        :param fail: A list of failure dictionaries from asserts.get_fail_dicts()
-        :return: A dictionary whose keys describe specific modes of failure,
-                and whose values are a list of failure dictionaries.
-        """
-        assessment: Dict[str, Dict[str, Any]] = {}
-        for one_failure in fail:
-            failure_modes: List[str] = assessment.keys()
-            failure_mode: str = self.categorize_one_failure(one_failure, failure_modes)
-            if failure_mode in failure_modes:
-                assessment[failure_mode].append(one_failure)
-            else:
-                assessment[failure_mode] = [one_failure]
-
-        return assessment
-
-    def output_failures(self, assessment: Dict[str, Dict[str, Any]], num_total: int):
-        """
-        Output the results of the failure assessment
-        :param assessment: A dictionary whose keys describe specific modes of failure,
-                and whose values are a list of failure dictionaries.
-        :param num_total: The total number of attempts, including passing attempts.
-        """
-        num_fail: int = 0
-        for failure_list in assessment.values():
-            num_fail += len(failure_list)
-
-        # Sort the modes of failure by how often they occurred,
-        # with the most common appearing at the beginning of the list.
-        # The item[1] in the lambda is a list of failure dictionaries corresponding to the failure mode.
-        # What is returned from sorted() is a list of key/value tuples which are reassembled
-        # back into a sorted dictionary where earlier entries reflects higher occurrence.
-        sorted_assessment: Dict[str, List[Dict[str, Any]]] = \
-            dict(sorted(assessment.items(), key=lambda item: len(item[1]), reverse=True))
-
-        print(f"{num_fail}/{num_total} attempts failed.")
-        print("Modes of failure:")
-        for failure_mode, failure_list in sorted_assessment.items():
-            mode_count: int = len(failure_list)
-            percent: float = 100.0 * mode_count / num_fail
-            print("")
-            print(f"{mode_count}/{num_fail} failures ({percent:.2f}%):")
-            print(f"{failure_mode}")
 
     def parse_args(self):
         """
@@ -182,6 +136,53 @@ The known failure_modes are:
 
         raw_answer: str = processor.get_answer()
         return raw_answer
+
+    def assess_failures(self, fail: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+        """
+        Assess the failures in a failure list
+
+        :param fail: A list of failure dictionaries from asserts.get_fail_dicts()
+        :return: A dictionary whose keys describe specific modes of failure,
+                and whose values are a list of failure dictionaries.
+        """
+        assessment: Dict[str, Dict[str, Any]] = {}
+        for one_failure in fail:
+            failure_modes: List[str] = assessment.keys()
+            failure_mode: str = self.categorize_one_failure(one_failure, failure_modes)
+            if failure_mode in failure_modes:
+                assessment[failure_mode].append(one_failure)
+            else:
+                assessment[failure_mode] = [one_failure]
+
+        return assessment
+
+    def output_failures(self, assessment: Dict[str, Dict[str, Any]], num_total: int):
+        """
+        Output the results of the failure assessment
+        :param assessment: A dictionary whose keys describe specific modes of failure,
+                and whose values are a list of failure dictionaries.
+        :param num_total: The total number of attempts, including passing attempts.
+        """
+        num_fail: int = 0
+        for failure_list in assessment.values():
+            num_fail += len(failure_list)
+
+        # Sort the modes of failure by how often they occurred,
+        # with the most common appearing at the beginning of the list.
+        # The item[1] in the lambda is a list of failure dictionaries corresponding to the failure mode.
+        # What is returned from sorted() is a list of key/value tuples which are reassembled
+        # back into a sorted dictionary where earlier entries reflects higher occurrence.
+        sorted_assessment: Dict[str, List[Dict[str, Any]]] = \
+            dict(sorted(assessment.items(), key=lambda item: len(item[1]), reverse=True))
+
+        print(f"{num_fail}/{num_total} attempts failed.")
+        print("Modes of failure:")
+        for failure_mode, failure_list in sorted_assessment.items():
+            mode_count: int = len(failure_list)
+            percent: float = 100.0 * mode_count / num_fail
+            print("")
+            print(f"{mode_count}/{num_fail} failures ({percent:.2f}%):")
+            print(f"{failure_mode}")
 
 
 if __name__ == '__main__':

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -86,7 +86,9 @@ class Assessor:
         arg_parser.add_argument("--test_hocon", type=str,
                                 help="The test case .hocon file to use as a basis for assessment")
         arg_parser.add_argument("--assessor_agent", type=str, default=None,
-                                help="The assessor agent to use. A default of None implies use of neuro-san stock assess_failure.hocon")
+                                help="""
+The assessor agent to use. A default of None implies use of neuro-san stock assess_failure.hocon
+""")
         arg_parser.add_argument("--connection", default="direct", type=str,
                                 choices=["grpc", "direct", "http", "https"],
                                 help="""

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -182,7 +182,19 @@ The known failure_modes are:
             percent: float = 100.0 * mode_count / num_fail
             print("")
             print(f"{mode_count}/{num_fail} failures ({percent:.2f}%):")
+            print("Failure Mode:")
             print(f"{failure_mode}")
+            print("")
+            for index, fail_dict in enumerate(failure_list):
+                print(f"    Example {index}:")
+                text_sample: str = fail_dict.get("text_sample")
+                text_sample = text_sample.strip()
+                print(f"    {text_sample}")
+
+            acceptance_criteria: str = fail_dict.get("acceptance_criteria")
+            acceptance_criteria = acceptance_criteria.strip()
+            print("    Acceptance Criteria:")
+            print(f"    {acceptance_criteria}")
 
 
 if __name__ == '__main__':

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -184,8 +184,8 @@ The known failure_modes are:
             print(f"{mode_count}/{num_fail} failures ({percent:.2f}%):")
             print("Failure Mode:")
             print(f"{failure_mode}")
-            print("")
             for index, fail_dict in enumerate(failure_list):
+                print("")
                 print(f"    Example {index}:")
                 text_sample: str = fail_dict.get("text_sample")
                 text_sample = text_sample.strip()
@@ -193,6 +193,7 @@ The known failure_modes are:
 
             acceptance_criteria: str = fail_dict.get("acceptance_criteria")
             acceptance_criteria = acceptance_criteria.strip()
+            print("")
             print("    Acceptance Criteria:")
             print(f"    {acceptance_criteria}")
 

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -147,13 +147,19 @@ The known failure_modes are:
         :return: A dictionary whose keys describe specific modes of failure,
                 and whose values are a list of failure dictionaries.
         """
+        # Loop through each failure dictionary and categorize each one.
         assessment: Dict[str, Dict[str, Any]] = {}
         for one_failure in fail:
+
+            # Always use our latest-greatest list of known failure modes.
             failure_modes: List[str] = assessment.keys()
             failure_mode: str = self.categorize_one_failure(one_failure, failure_modes)
+
+            # If we have seen this failure before, add to the existing list.
             if failure_mode in failure_modes:
                 assessment[failure_mode].append(one_failure)
             else:
+                # ... otherwise make a new list for more potential matches later.
                 assessment[failure_mode] = [one_failure]
 
         return assessment

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -191,7 +191,7 @@ The known failure_modes are:
                 text_sample = text_sample.strip()
                 print(f"    {text_sample}")
 
-            acceptance_criteria: str = fail_dict.get("acceptance_criteria")
+            acceptance_criteria: str = failure_list[0].get("acceptance_criteria")
             acceptance_criteria = acceptance_criteria.strip()
             print("")
             print("    Acceptance Criteria:")

--- a/neuro_san/test/assessor/assessor.py
+++ b/neuro_san/test/assessor/assessor.py
@@ -186,7 +186,7 @@ The known failure_modes are:
             print(f"{failure_mode}")
             for index, fail_dict in enumerate(failure_list):
                 print("")
-                print(f"    Example {index}:")
+                print(f"    Example {index+1}:")
                 text_sample: str = fail_dict.get("text_sample")
                 text_sample = text_sample.strip()
                 print(f"    {text_sample}")

--- a/neuro_san/test/assessor/assessor_assert_forwarder.py
+++ b/neuro_san/test/assessor/assessor_assert_forwarder.py
@@ -18,6 +18,9 @@ from neuro_san.test.interfaces.assert_forwarder import AssertForwarder
 class AssessorAssertForwarder(AssertForwarder):
     """
     AssertForwarder implemetation for the agent Assessor.
+
+    This guy generally does not care about the correctness of the asserts themselves,
+    but serves to collect failure data for the Assessor.
     """
 
     def __init__(self):

--- a/neuro_san/test/assessor/assessor_assert_forwarder.py
+++ b/neuro_san/test/assessor/assessor_assert_forwarder.py
@@ -100,7 +100,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param second: Second comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     def assertNotEqual(self, first: Any, second: Any, msg: str = None):
         """
@@ -110,7 +110,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param second: Second comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     def assertIs(self, first: Any, second: Any, msg: str = None):
         """
@@ -120,7 +120,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param second: Second comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     def assertIsNot(self, first: Any, second: Any, msg: str = None):
         """
@@ -130,7 +130,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param second: Second comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     def assertIsNone(self, expr: Any, msg: str = None):
         """
@@ -139,7 +139,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param expr: Expression to test
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     def assertIsNotNone(self, expr: Any, msg: str = None):
         """
@@ -148,7 +148,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param expr: Expression to test
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     def assertIn(self, member: Any, container: Any, msg: str = None):
         """
@@ -158,7 +158,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param container: Container comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     def assertNotIn(self, member: Any, container: Any, msg: str = None):
         """
@@ -168,7 +168,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param container: Container comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     # pylint: disable=invalid-name
     def assertIsInstance(self, obj: Any, cls: Any, msg: str = None):
@@ -179,7 +179,7 @@ class AssessorAssertForwarder(AssertForwarder):
         :param cls: Class comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing
 
     # pylint: disable=invalid-name
     def assertNotIsInstance(self, obj: Any, cls: Any, msg: str = None):
@@ -190,4 +190,4 @@ class AssessorAssertForwarder(AssertForwarder):
         :param cls: Class comparison element
         :param msg: optional string message
         """
-        pass
+        # Do nothing

--- a/neuro_san/test/assessor/assessor_assert_forwarder.py
+++ b/neuro_san/test/assessor/assessor_assert_forwarder.py
@@ -1,0 +1,193 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import Dict
+from typing import List
+
+from neuro_san.test.interfaces.assert_forwarder import AssertForwarder
+
+
+class AssessorAssertForwarder(AssertForwarder):
+    """
+    AssertForwarder implemetation for the agent Assessor.
+    """
+
+    def __init__(self):
+        """
+        Constructor
+        """
+        self.num_total: int = 0
+        self.fail: List[Dict[str, Any]] = []
+
+    def get_num_total(self) -> int:
+        """
+        :return: The total number of test cases seen
+        """
+        return self.num_total
+
+    def get_fail_dicts(self) -> List[Dict[str, Any]]:
+        """
+        :return: The failure dictionaries for further analysis
+        """
+        return self.fail
+
+    def assertTrue(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is true
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        self.handle_assert(bool(expr), True, msg)
+
+    def assertFalse(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is false
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        self.handle_assert(bool(expr), False, msg)
+
+    def handle_assert(self, is_passing: bool, sense: bool, msg: str):
+        """
+        Handle the assert.
+        :param is_passing: Boolean as to whether or not the test is passing.
+        :param sense: Whether the test was supposed to be true or false.
+        :param msg: The assert message to parse.
+        """
+        self.num_total += 1
+        if is_passing == sense:
+            return
+
+        components: Dict[str, Any] = self.parse_assert_message(msg)
+        components["sense"] = sense
+        self.fail.append(components)
+
+    def parse_assert_message(self, message: str) -> Dict[str, Any]:
+        """
+        Parse a single assert message into its parts.
+        :param message: The assert message from GistAgentEvaluator
+        :return: A dictionary with the relevant components of the message
+        """
+
+        # See GistAgentEvaluator for format.
+        acceptance_split: List[str] = message.split("acceptance_criteria:")
+        sample_split: List[str] = acceptance_split[0].split("text_sample:")
+
+        components: Dict[str, Any] = {
+            # Get what comes after the "acceptance_criteria" delimiter
+            "acceptance_criteria": acceptance_split[-1],
+
+            # Get what comes after the "text_sample" delimiter
+            "text_sample": sample_split[-1]
+        }
+        return components
+
+    def assertEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is equal to the second
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        pass
+
+    def assertNotEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is not equal to the second
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        pass
+
+    def assertIs(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first and second are the same object
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        pass
+
+    def assertIsNot(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first and second are not the same object
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        pass
+
+    def assertIsNone(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is None
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        pass
+
+    def assertIsNotNone(self, expr: Any, msg: str = None):
+        """
+        Assert that the expression is not None
+
+        :param expr: Expression to test
+        :param msg: optional string message
+        """
+        pass
+
+    def assertIn(self, member: Any, container: Any, msg: str = None):
+        """
+        Assert that the member is in the container
+
+        :param member: Member comparison element
+        :param container: Container comparison element
+        :param msg: optional string message
+        """
+        pass
+
+    def assertNotIn(self, member: Any, container: Any, msg: str = None):
+        """
+        Assert that the member is not in the container
+
+        :param member: Member comparison element
+        :param container: Container comparison element
+        :param msg: optional string message
+        """
+        pass
+
+    # pylint: disable=invalid-name
+    def assertIsInstance(self, obj: Any, cls: Any, msg: str = None):
+        """
+        Assert that the obj is an instance of the cls
+
+        :param obj: object instance comparison element
+        :param cls: Class comparison element
+        :param msg: optional string message
+        """
+        pass
+
+    # pylint: disable=invalid-name
+    def assertNotIsInstance(self, obj: Any, cls: Any, msg: str = None):
+        """
+        Assert that the obj is not an instance of the cls
+
+        :param obj: object instance comparison element
+        :param cls: Class comparison element
+        :param msg: optional string message
+        """
+        pass

--- a/neuro_san/test/assessor/assessor_assert_forwarder.py
+++ b/neuro_san/test/assessor/assessor_assert_forwarder.py
@@ -191,3 +191,47 @@ class AssessorAssertForwarder(AssertForwarder):
         :param msg: optional string message
         """
         # Do nothing
+
+    # pylint: disable=invalid-name
+    def assertGreater(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        # Do nothing
+
+    # pylint: disable=invalid-name
+    def assertGreaterEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        # Do nothing
+
+    # pylint: disable=invalid-name
+    def assertLess(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        # Do nothing
+
+    # pylint: disable=invalid-name
+    def assertLessEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        # Do nothing

--- a/neuro_san/test/driver/assert_capture.py
+++ b/neuro_san/test/driver/assert_capture.py
@@ -198,3 +198,59 @@ class AssertCapture(AssertForwarder):
             self.basis.assertNotIsInstance(obj, cls, msg)
         except AssertionError as exception:
             self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertGreater(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertGreater(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertGreaterEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertGreaterEqual(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertLess(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertLess(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)
+
+    # pylint: disable=invalid-name
+    def assertLessEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        try:
+            self.basis.assertLessEqual(first, second, msg)
+        except AssertionError as exception:
+            self.asserts.append(exception)

--- a/neuro_san/test/driver/data_driven_agent_test_driver.py
+++ b/neuro_san/test/driver/data_driven_agent_test_driver.py
@@ -137,12 +137,12 @@ Need at least {num_need_success} to consider {hocon_file} test to be successful.
             # Make single strings into a list for consistent parsing
             connections = [connections]
         asserts.assertIsInstance(connections, List)
-        asserts.assertTrue(len(connections) > 0)
+        asserts.assertGreater(len(connections), 0)
 
         # Collect the interations to test for
         empty: List[Any] = []
         interactions: List[Dict[str, Any]] = test_case.get("interactions", empty)
-        asserts.assertTrue(len(interactions) > 0)
+        asserts.assertGreater(len(interactions), 0)
 
         # Collect other session information
         use_direct: bool = test_case.get("use_direct", False)

--- a/neuro_san/test/driver/data_driven_agent_test_driver.py
+++ b/neuro_san/test/driver/data_driven_agent_test_driver.py
@@ -49,8 +49,6 @@ class DataDrivenAgentTestDriver:
         """
         self.asserts_basis: AssertForwarder = asserts
         self.fixtures: FileOfClass = fixtures
-        if self.fixtures is None:
-            self.fixtures = FileOfClass(__file__, path_to_basis="../../fixtures")
 
     def one_test(self, hocon_file: str):
         """
@@ -168,7 +166,9 @@ Need at least {num_need_success} to consider {hocon_file} test to be successful.
 
         :param hocon_file: The name of the hocon from the fixtures directory.
         """
-        test_path: str = self.fixtures.get_file_in_basis(hocon_file)
+        test_path: str = hocon_file
+        if self.fixtures is not None:
+            test_path = self.fixtures.get_file_in_basis(hocon_file)
         hocon = EasyHoconPersistence(must_exist=True)
         test_case: Dict[str, Any] = hocon.restore(file_reference=test_path)
         return test_case

--- a/neuro_san/test/driver/data_driven_agent_test_driver.py
+++ b/neuro_san/test/driver/data_driven_agent_test_driver.py
@@ -169,7 +169,7 @@ Need at least {num_need_success} to consider {hocon_file} test to be successful.
         :param hocon_file: The name of the hocon from the fixtures directory.
         """
         test_path: str = self.fixtures.get_file_in_basis(hocon_file)
-        hocon = EasyHoconPersistence()
+        hocon = EasyHoconPersistence(must_exist=True)
         test_case: Dict[str, Any] = hocon.restore(file_reference=test_path)
         return test_case
 

--- a/neuro_san/test/evaluators/gist_agent_evaluator.py
+++ b/neuro_san/test/evaluators/gist_agent_evaluator.py
@@ -90,7 +90,7 @@ acceptance_criteria:
         :return: A boolean value as to whether or not the text_sample passes the acceptance_criteria.
         """
         text: str = f"""
-The acceptance_criterion is:
+The acceptance_criteria is:
 "{acceptance_criteria}".
 
 The text_sample is:

--- a/neuro_san/test/evaluators/gist_agent_evaluator.py
+++ b/neuro_san/test/evaluators/gist_agent_evaluator.py
@@ -128,6 +128,6 @@ The text_sample is:
         test_passes: bool = passing and not failing
         test_fails: bool = failing and not passing
         only_one: bool = test_passes or test_fails
-        self.asserts.assertTrue(only_one)
+        self.asserts.assertEquals(only_one, True)
 
         return test_passes

--- a/neuro_san/test/evaluators/gist_agent_evaluator.py
+++ b/neuro_san/test/evaluators/gist_agent_evaluator.py
@@ -128,6 +128,9 @@ The text_sample is:
         test_passes: bool = passing and not failing
         test_fails: bool = failing and not passing
         only_one: bool = test_passes or test_fails
-        self.asserts.assertEquals(only_one, True)
+
+        # Specifically use assertEqual() here to reserve assertTrue/False for
+        # whether or not the test itself passed, as those feed into the Assessor.
+        self.asserts.assertEqual(only_one, True)
 
         return test_passes

--- a/neuro_san/test/interfaces/assert_forwarder.py
+++ b/neuro_san/test/interfaces/assert_forwarder.py
@@ -143,3 +143,47 @@ class AssertForwarder:
         :param msg: optional string message
         """
         raise NotImplementedError
+
+    # pylint: disable=invalid-name
+    def assertGreater(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        raise NotImplementedError
+
+    # pylint: disable=invalid-name
+    def assertGreaterEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        raise NotImplementedError
+
+    # pylint: disable=invalid-name
+    def assertLess(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        raise NotImplementedError
+
+    # pylint: disable=invalid-name
+    def assertLessEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        raise NotImplementedError

--- a/neuro_san/test/unittest/unit_test_assert_forwarder.py
+++ b/neuro_san/test/unittest/unit_test_assert_forwarder.py
@@ -145,3 +145,47 @@ class UnitTestAssertForwarder(AssertForwarder):
         :param msg: optional string message
         """
         self.test_case.assertNotIsInstance(obj, cls, msg=msg)
+
+    # pylint: disable=invalid-name
+    def assertGreater(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        self.test_case.assertGreater(first, second, msg=msg)
+
+    # pylint: disable=invalid-name
+    def assertGreaterEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is greater than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        self.test_case.assertGreaterEqual(first, second, msg=msg)
+
+    # pylint: disable=invalid-name
+    def assertLess(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        self.test_case.assertLess(first, second, msg=msg)
+
+    # pylint: disable=invalid-name
+    def assertLessEqual(self, first: Any, second: Any, msg: str = None):
+        """
+        Assert that the first is less than or equal to the second.
+
+        :param first: First comparison element
+        :param second: Second comparison element
+        :param msg: optional string message
+        """
+        self.test_case.assertLessEqual(first, second, msg=msg)

--- a/tests/fixtures/hello_world/hello_world.hocon
+++ b/tests/fixtures/hello_world/hello_world.hocon
@@ -1,0 +1,46 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+# This file defines everything necessary for a data-driven test.
+{
+    # Describes what agent to test against.
+    "agent": "hello_world",
+
+    # Needs to success N times out of M
+    "success_ratio": "3/3", 
+
+    # Interactions are a series of dictionaries with request elements paired with
+    # descriptions of response checks.
+    "interactions": [
+        {
+            # This is what we send as input to streaming_chat()
+            "text": """
+From earth, I approach a new planet and wish to send a short 2-word greeting to the new orb.
+""",
+
+            # The response block treats how we are going to test what comes back
+            "response": {
+
+                # Text block says how we are going to examine the text of the response.
+                "text": {
+
+                    # Gist says we are going to ask an LLM about how the response
+                    # matches up to our description of acceptance criteria.
+                    # Each component of the list needs to pass muster in order to pass.
+                    "gist": ["""
+The text sample should have 2 words and say 'Hello world'.
+Capitalization and punctuation do not matter.
+"""                 ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/fixtures/hello_world/hello_world.hocon
+++ b/tests/fixtures/hello_world/hello_world.hocon
@@ -35,10 +35,7 @@ From earth, I approach a new planet and wish to send a short 2-word greeting to 
                     # Gist says we are going to ask an LLM about how the response
                     # matches up to our description of acceptance criteria.
                     # Each component of the list needs to pass muster in order to pass.
-                    "gist": ["""
-The text sample should have 2 words and say 'Hello world'.
-Capitalization and punctuation do not matter.
-"""                 ]
+                    "gist": ["The text sample should have 2 words and say 'Hello world'. Capitalization and punctuation do not matter."]
                 }
             }
         }


### PR DESCRIPTION
* First attempt at an agent failure Assessor that, with the aid of a hocon test case, can report failure classifications on repeated test attempts that use the "gist" evaluator.
* Some adding to AssertForwarder and pals to make certain failures more specific.
* Create a test case for hello_world and use it to begin to repair the prompts there. Still not perfect, but actually passes much more often than before.
* Update README with more reliable hello_world findings.

Some other random fixes:
* Remove "service" as a connection option from agent_cli.py.  Let's be specific, people.
* Tweak to Dockerfile to reference python logging cookbook.
* Remove redundancy in README

Sample output of the Assessor:
```
$ python -m neuro_san.test.assessor.assessor --test_hocon tests/fixtures/hello_world/hello_world.hocon 
Testing tests/fixtures/hello_world/hello_world.hocon:
2/3 attempts passed.
1/3 attempts failed.
Modes of failure:

1/1 failures (100.00%):
Failure Mode:
The text sample contains the wrong second word.

    Example 1:
    Hello, globe

    Acceptance Criteria:
    The text sample should have 2 words and say 'Hello world'. Capitalization and punctuation do not matter.
```

There is more work to do, but this is a decent first stab.