### PR TITLE
Test case hocon reference doc

### DIFF
--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -357,6 +357,7 @@ To do this we use a separate agent to test the value against the criteria to mak
 response matches the "gist" of the criteria.
 
 If the response from the agent we are testing matches the "gist" of the given criteria, the test passes.
+
 Similarly the "not_gist" test passes when the response does not match the "gist" of the given criteria.
 
 ## Use with the Assessor

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -1,4 +1,4 @@
-# LLM Info HOCON File Reference
+# Data-Driven Test Case HOCON File Reference
 
 This document describes the neuro-san specifications for the test case .hocon files
 found within this repo under the [tests/fixtures](../tests/fixtures) section of this repo.
@@ -15,7 +15,7 @@ Sub-keys to those dictionaries will be described in the next-level down heading 
 
 <!--TOC-->
 
-- [LLM Info HOCON File Reference](#llm-info-hocon-file-reference)
+- [Data-Driven Test Case HOCON File Reference](#data-driven-test-case-hocon-file-reference)
   - [Data-Driven Test Case Specifications](#data-driven-test-case-specifications)
     - [agent](#agent)
     - [connections](#connections)

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -159,7 +159,7 @@ on to the next interaction dictionary.
 The only other honored value is "MAXIMAL", indicating full debug information should
 come back to the client.  This ends up being a lot more messages.
 
-_Future_ iterations of the test infrastructure we may elect to test at the level of
+_Future_ iterations of the test infrastructure may elect to test at the level of
 this fine-grained MAXIMAL debug information.
 
 #### continue_conversation

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -187,8 +187,8 @@ Keys in this response dictionary describe specific parts of the response that ar
 be tested.  The values for each key are themselves dictionaries that describe potentially
 multiple tests to be done on the area of focus on the response described by the key.
 
-First we will describe the keys whose values can be tested, like [text](#test-response)
-and [sly_data](#sly-data-response) each in its own subheading.
+First we will describe the keys whose values can be tested, like [text](#text-response)
+and [sly_data](#sly_data-response) each in its own subheading.
 Then we will describe the [Stock Tests](#stock-tests) able to be performed on each
 response datum.
 
@@ -230,7 +230,7 @@ contains this interaction definition:
 The first "text" asks the agent the question "Who did Yellow Submarine?" in its request.
 In the "response" block, it is the "text" of the corresponding response that is to be tested.
 We could set up multiple tests here, but for this simple example we are electing to test
-the agent's "answer" against containing the [keyword](#keyword-not-keyword) "Beatles".
+the agent's "answer" against containing the [keyword](#keywordsnot-keyword) "Beatles".
 The test doesn't care about exact verbiage of the "answer" from the agent, all that matters
 is that somewhere in the text, the keyword "Beatles" is in there.
 
@@ -287,7 +287,7 @@ contains this interaction definition:
 In this response part, what is being tested is the sly_data dictionary returned with "the answer".
 That dictionary is expected to have a single key called "equals".  The value for that "equals"
 key is tested against all of the tests listed in the corrsponding dictionary. In this case,
-there is a single "value" check against the number 19481.0.
+there is a single [value](#valuenot_value) check against the number 19481.0.
 
 Note that for sly_data, it's possible to return nested dictionaries.
 To test the key/value pairs inside nested dictionaries, simply nest your test dictionaries.

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -286,7 +286,7 @@ contains this interaction definition:
 
 In this response part, what is being tested is the sly_data dictionary returned with "the answer".
 That dictionary is expected to have a single key called "equals".  The value for that "equals"
-key is tested against all of the tests listed in the corrsponding dictionary. In this case,
+key is tested against all of the tests listed in the corresponding dictionary. In this case,
 there is a single [value](#valuenot_value) check against the number 19481.0.
 
 Note that for sly_data, it's possible to return nested dictionaries.

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -331,7 +331,7 @@ For numbers, this is the expected inequality. For strings, this is a lexicograph
 If what is tested is greater than the value mentioned, the test will pass. This is just like
 [TestCase.assertGreater](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertGreater)
 
-Similarly the "not_greatre" test looks for a value that is considered less than or equal to what is given.
+Similarly the "not_greater" test looks for a value that is considered less than or equal to what is given.
 If what is tested is <= than the value mentioned, the test will pass. This is just like
 [TestCase.assertLessEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLessEqual)
 

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -316,7 +316,7 @@ This is just like
 ###### less/not_less
 
 The "less" test looks for a value that is considered less than what is given.
-For numbers, this is the expected inequality. For strings, this is a lexicographal comparison.
+For numbers, this is the expected inequality. For strings, this is a lexicographical comparison.
 If what is tested is less than the value mentioned, the test will pass. This is just like
 [TestCase.assertLess](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLess)
 
@@ -327,7 +327,7 @@ If what is tested is >= than the value mentioned, the test will pass. This is ju
 ###### greater/not_greater
 
 The "greater" test looks for a value that is considered greater than what is given.
-For numbers, this is the expected inequality. For strings, this is a lexicographal comparison.
+For numbers, this is the expected inequality. For strings, this is a lexicographical comparison.
 If what is tested is greater than the value mentioned, the test will pass. This is just like
 [TestCase.assertGreater](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertGreater)
 

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -82,7 +82,7 @@ in order to call the test passing.
 The big idea here is that this is an acknowledgement of the realities of working with LLMs:
 
 * agents do not always do what you want them to
-* getting agents to give you correct output given existing prompts and a prticular input is fundamentally an optimization exercise against the prompts themselves.
+* getting agents to give you correct output given existing prompts and a particular input is fundamentally an optimization exercise against the prompts themselves.
 
 The denominator (bottom) of the fraction is an integer indicating how many test samples (repeat iterations)
 should be attempted.

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -53,9 +53,9 @@ this value should only be the stem of that file.
 
 Single string values can be:
 
-| connection type | meanining |
+| value | meaning |
 |:----------------|:----------|
-| direct (default)| Connect directly to the agent via a neuro-san library call. No server required. |
+| direct (default)| Connect directly to the agent via a neuro-san library call - no server required. |
 | http  |  Connect to the agent via a server via http |
 | grpc  |  Connect to the agent via a server via gRPC |
 | https |  Connect to the agent via a server via gRPC |
@@ -108,6 +108,7 @@ When True, no new socket is created and a direct/library connection is used inst
 ### metadata
 
 A dictionary of request metadata to send along to a server for each interaction.
+
 What is required of request metadata dictionaries is server specific.
 The default server implementation doesn't require anything for request metadata,
 however some servers may require this to contain bearer tokens for access,
@@ -142,6 +143,7 @@ What is required here depends on the agent itself, and ideally what is required
 is at least documented in the agent's hocon file.
 
 Superfluous information is passed, taking up space, but ignored.
+
 The default value is None.
 
 #### chat_filter
@@ -158,7 +160,7 @@ The only other honored value is "MAXIMAL", indicating full debug information sho
 come back to the client.  This ends up being a lot more messages.
 
 _Future_ iterations of the test infrastructure we may elect to test at the level of
-this fine-grained debug information.
+this fine-grained MAXIMAL debug information.
 
 #### continue_conversation
 
@@ -178,6 +180,8 @@ A dictionary describing how to test various aspects of the response from the age
 By default this is an empty dictionary, indicating no tests should be done on this
 iteration of the conversation with the agent.  An empty response is valuable for at
 least advancing the conversation forward to a point of interest that you'd like to test.
+
+This is kind of abstract, so please try to follow:
 
 Keys in this response dictionary describe specific parts of the response that are to
 be tested.  The values for each key are themselves dictionaries that describe potentially
@@ -293,6 +297,11 @@ To test the key/value pairs inside nested dictionaries, simply nest your test di
 The following are lists of the stock test keywords and their negations that come with the
 test infrastructure.
 
+For any of these tests, the name of the test itself is specified as a key in a dictionary.
+The value part describes what the response should be tested against.
+These values can either be single scalar values (string, int, etc) or a list of values.
+When specifying a list of values for a test, each value listed must pass.
+
 ###### value/not_value
 
 The "value" test looks for a specific value.  If what is in the response is the exact value
@@ -352,7 +361,7 @@ Similarly the "not_gist" test passes when the response does not match the "gist"
 
 ## Use with the Assessor
 
-The (Assessor)[../neuro_san/test/assesor/assessor.py) is a tool which uses these data-driven test cases
+The [Assessor](../neuro_san/test/assesor/assessor.py) is a tool which uses these data-driven test cases
 as a basis for gathering repeated test samples so as to assess how often the test case will pass.
 You give the assessor a test case hocon file, it looks at the [success_ratio](#success-ratio) denominator
 to see how many test samples it should run.  As it gathers its output for each test sample, it

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -28,10 +28,11 @@ Single string values can be:
 
 | connection type | meanining |
 |:----------------|:----------|
-| direct (default)| Do not use a server when conducting a test, connect directly to the agent via a neuro-san library call. |
+| direct (default)| Connect directly to the agent via a neuro-san library call. No server required. |
 | http  |  Connect to the agent via a server via http |
 | grpc  |  Connect to the agent via a server via gRPC |
 | https |  Connect to the agent via a server via gRPC |
+
 
 Note that it is possible to specify a list of connection types for the same test case.
 If this is the case, the test driver will conduct the same test via each connection type.
@@ -43,6 +44,8 @@ Example of a list:
     "connections": [ "direct", "http", "grpc" ]
     ...
 ```
+
+Currently, only testing against a locally running server is supported.
 
 ### success_ratio
 

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -58,7 +58,7 @@ Single string values can be:
 | direct (default)| Connect directly to the agent via a neuro-san library call - no server required. |
 | http  |  Connect to the agent via a server via http |
 | grpc  |  Connect to the agent via a server via gRPC |
-| https |  Connect to the agent via a server via gRPC |
+| https |  Connect to the agent via a server via secure http |
 
 
 Note that it is possible to specify a list of connection types for the same test case.

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -13,6 +13,33 @@ header they pertain to.
 Some key descriptions refer to values that are dictionaries.
 Sub-keys to those dictionaries will be described in the next-level down heading scope from their parent.
 
+<!--TOC-->
+
+- [LLM Info HOCON File Reference](#llm-info-hocon-file-reference)
+  - [Data-Driven Test Case Specifications](#data-driven-test-case-specifications)
+    - [agent](#agent)
+    - [connections](#connections)
+    - [success_ratio](#success_ratio)
+    - [use_direct](#use_direct)
+    - [metadata](#metadata)
+    - [interactions](#interactions)
+      - [text](#text)
+      - [sly_data](#sly_data)
+      - [chat_filter](#chat_filter)
+      - [continue_conversation](#continue_conversation)
+      - [response](#response)
+        - [text (response)](#text-response)
+        - [sly_data (response)](#sly_data-response)
+        - [Stock Tests](#stock-tests)
+          - [value/not_value](#valuenot_value)
+          - [less/not_less](#lessnot_less)
+          - [greater/not_greater](#greaternot_greater)
+          - [keywords/not_keywords](#keywordsnot_keywords)
+          - [gist/not_gist](#gistnot_gist)
+  - [Use with the Assessor](#use-with-the-assessor)
+
+<!--TOC-->
+
 ## Data-Driven Test Case Specifications
 
 ### agent
@@ -53,6 +80,7 @@ A string value that represents the fraction of test attempts that need to succee
 in order to call the test passing.
 
 The big idea here is that this is an acknowledgement of the realities of working with LLMs:
+
 * agents do not always do what you want them to
 * getting agents to give you correct output given existing prompts and a prticular input is fundamentally an optimization exercise against the prompts themselves.
 

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -1,0 +1,85 @@
+# LLM Info HOCON File Reference
+
+This document describes the neuro-san specifications for the test case .hocon files
+found within this repo under the [tests/fixtures](../tests/fixtures) section of this repo.
+
+The neuro-san system uses the HOCON (Human-Optimized Config Object Notation) file format
+for its data-driven configuration elements.  Very simply put, you can think of
+.hocon files as JSON files that allow comments, but there is more to the hocon
+format than that which you can explore on your own.
+
+Specifications in this document each have header changes for the depth of scope of the dictionary
+header they pertain to.
+Some key descriptions refer to values that are dictionaries.
+Sub-keys to those dictionaries will be described in the next-level down heading scope from their parent.
+
+## Data-Driven Test Case Specifications
+
+### agent
+
+The value gives the string name of the agent to be tested.
+
+While all agents are named according to the filename of their agent network hocon file,
+this value should only be the stem of that file.
+
+### connections
+
+Single string values can be:
+
+| connection type | meanining |
+|:----------------|:----------|
+| direct (default)| Do not use a server when conducting a test, connect directly to the agent via a neuro-san library call. |
+| http  |  Connect to the agent via a server via http |
+| grpc  |  Connect to the agent via a server via gRPC |
+| https |  Connect to the agent via a server via gRPC |
+
+Note that it is possible to specify a list of connection types for the same test case.
+If this is the case, the test driver will conduct the same test via each connection type.
+
+Example of a list:
+
+```
+    ...
+    "connections": [ "direct", "http", "grpc" ]
+    ...
+```
+
+### success_ratio
+
+A string value that represents the fraction of test attempts that need to succeed
+in order to call the test passing.
+
+The big idea here is that this is an acknowledgement of the realities of working with LLMs:
+* agents do not always do what you want them to
+* getting agents to give you correct output given existing prompts and a prticular input is fundamentally an optimization exercise against the prompts themselves.
+
+The denominator (bottom) of the fraction is an integer indicating how many test samples (repeat iterations)
+should be attempted.
+
+The numerator (top) of the fraction is an integer indicating how many of those test samples
+need to execute without failure in order to call the test "passing" within a unit test infrastructure
+that needs some kind of boolean assessment.
+
+When using the (Assessor)[../neuro_san/test/assessor/assessor.py] tool to categorize modes of failure,
+the denominator here is also used as the indication of how many test samples should be taken.
+
+By default this value is "1/1" indicating that the test case will only run once,
+and that single test sample *must* pass in order to "pass".  This is in keeping with
+standard expectations w/ non-statistically-oriented tests.
+
+### use_direct
+### metadata
+### interactions
+#### text
+#### sly_data
+#### response
+##### text
+####### tests
+######## value/not_value
+######## less/not_less
+######## greater/not_greater
+######## keywords/not_keywords
+######## gist/not_gist
+##### sly_data
+#### chat_filter
+#### continue_conversation

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -71,18 +71,263 @@ and that single test sample *must* pass in order to "pass".  This is in keeping 
 standard expectations w/ non-statistically-oriented tests.
 
 ### use_direct
+
+Boolean value that describes how an external agent is called.
+When False (the default), a grpc call is used to contact the server of the external agent,
+even if it is on the same server.
+When True, no new socket is created and a direct/library connection is used instead.
+
 ### metadata
+
+A dictionary of request metadata to send along to a server for each interaction.
+What is required of request metadata dictionaries is server specific.
+The default server implementation doesn't require anything for request metadata,
+however some servers may require this to contain bearer tokens for access,
+or extra user-identifying information for logging.
+
+By default the value for this dictionary is None.
+
 ### interactions
+
+A list of dictionaries, where each entry is an interaction with the test cases's agent
+to futher the progression of the single test case.  Component dictionaries representing
+requests and tests on those responses are executed sequentially according to their order
+in the interactions list.
+
+In general, most keys of each component dictionary describe what to send in a request to
+the test case's agent, however the most important entry for each dictionary is the
+value of the [response](#response) key - this is where the tests on what is returned
+are defined.
+
 #### text
+
+A single user message string to send to the agent as input.
+Default value is None.
+
 #### sly_data
-#### response
-##### text
-####### tests
-######## value/not_value
-######## less/not_less
-######## greater/not_greater
-######## keywords/not_keywords
-######## gist/not_gist
-##### sly_data
+
+A dictionary of private data key/value pairs to associate with the input.
+Keys are always strings and values can be anything JSON-serializable,
+as long as the receiving agent will understand it.
+
+What is required here depends on the agent itself, and ideally what is required
+is at least documented in the agent's hocon file.
+
+Superfluous information is passed, taking up space, but ignored.
+The default value is None.
+
 #### chat_filter
+
+A string value which describes how the server should filter information it sends back
+to the client.
+
+The default value is "MINIMAL", indicating that all that is required to send back to
+the client is a single message containing "the answer" (however that is defined by the agent),
+and enough information for the test driver to continue the conversation with context
+on to the next interaction dictionary.
+
+The only other honored value is "MAXIMAL", indicating full debug information should
+come back to the client.  This ends up being a lot more messages.
+
+_Future_ iterations of the test infrastructure we may elect to test at the level of
+this fine-grained debug information.
+
 #### continue_conversation
+
+A boolean value indicating that the context of the conversation with the test case's agent
+should be continued on to the next interaction dictionary.
+
+By default, this value is true, indicating that subsequent interaction requests will take
+into account the previous requests and responses.
+
+When this value is false, it is as if at this point in the list of interactions
+you are starting a whole new clean-slate conversation.
+
+#### response
+
+A dictionary describing how to test various aspects of the response from the agent.
+
+By default this is an empty dictionary, indicating no tests should be done on this
+iteration of the conversation with the agent.  An empty response is valuable for at
+least advancing the conversation forward to a point of interest that you'd like to test.
+
+Keys in this response dictionary describe specific parts of the response that are to
+be tested.  The values for each key are themselves dictionaries that describe potentially
+multiple tests to be done on the area of focus on the response described by the key.
+
+First we will describe the keys whose values can be tested, like [text](#test-response)
+and [sly_data](#sly-data-response) each in its own subheading.
+Then we will describe the [Stock Tests](#stock-tests) able to be performed on each
+response datum.
+
+##### text (response)
+
+The text field of the response is a dictionary describing which tests to perform
+on the text part of the response from the agent's "answer".
+
+Each key corresponds to a specific test/assert in the [Stock Tests](#stock-tests),
+and its value can either be a single test value as verification criteria for the test
+to pass or a list of these values - all of which must pass the test.  (That is, list
+inclusion is an AND operation.)
+
+For instance, part of the (music_nerd test case)[../tests/fixtures/music_nerd/beatles_with_history.hocon]
+contains this interaction definition:
+
+```
+    "interactions": [
+        {
+            # This is what we send as input to streaming_chat()
+            "text": "Who did Yellow Submarine?",
+
+            # The response block treats how we are going to test what comes back
+            "response": {
+
+                # Text block says how we are going to examine the text of the response.
+                "text": {
+
+                    # Keywords says we are going to look for exact matches for each
+                    # element in a list of strings.  All elements need to show up
+                    # in order to pass.
+                    "keywords": ["Beatles"]
+                }
+            }
+        },
+        ...
+```
+
+The first "text" asks the agent the question "Who did Yellow Submarine?" in its request.
+In the "response" block, it is the "text" of the corresponding response that is to be tested.
+We could set up multiple tests here, but for this simple example we are electing to test
+the agent's "answer" against containing the [keyword](#keyword-not-keyword) "Beatles".
+The test doesn't care about exact verbiage of the "answer" from the agent, all that matters
+is that somewhere in the text, the keyword "Beatles" is in there.
+
+##### sly_data (response)
+
+The sly_data field of the response is a dictionary describing which tests to perform
+on the sly_data dictionary optioanlly returned as part of the response from the agent's "answer".
+
+Since the sly data is inherently a dictionary, we don't really want to test entire dictionary
+contents. Instead, what we want to test are specific values for particular keys inside the
+sly_data dictionary that was returned.  As such, each key in the test case's dictionary here
+corresponds to a specific key inside the returned sly_data that is to be tested.  The value
+is yet another dictionary that describes what to test, just like in [text](#text-response) above.
+
+Each key corresponds to a specific test/assert in the [Stock Tests](#stock-tests),
+and its value can either be a single test value as verification criteria for the test
+to pass or a list of these values - all of which must pass the test.  (That is, list
+inclusion is an AND operation.)
+
+For instance, part of the (math_guy test case)[../tests/fixtures/math_guy/basic_sly_data.hocon]
+contains this interaction definition:
+
+```
+    "interactions": [
+        {
+            # This is what we send as input to streaming_chat()
+            "text": "times",
+
+            "sly_data": {
+                "x": 847,
+                "y": 23
+            },
+
+            # The response block treats how we are going to test what comes back
+            "response": {
+
+                # Text block says how we are going to examine the text of the response.
+                "sly_data": {
+
+                    # Each key here corresponds to a key in the sly_data itself
+                    # that is returned.
+                    "equals": {
+                        # Value says we are going to look for exact values for each
+                        # element in a list of strings.  All elements need to show up
+                        # in order to pass.
+                        "value": [19481.0]
+                    }
+                }
+            }
+        }
+    ]
+```
+
+In this response part, what is being tested is the sly_data dictionary returned with "the answer".
+That dictionary is expected to have a single key called "equals".  The value for that "equals"
+key is tested against all of the tests listed in the corrsponding dictionary. In this case,
+there is a single "value" check against the number 19481.0.
+
+Note that for sly_data, it's possible to return nested dictionaries.
+To test the key/value pairs inside nested dictionaries, simply nest your test dictionaries.
+
+##### Stock Tests
+
+The following are lists of the stock test keywords and their negations that come with the
+test infrastructure.
+
+###### value/not_value
+
+The "value" test looks for a specific value.  If what is in the response is the exact value
+mentioned in the test case, the test will pass.  This is just like
+[TestCase.assertEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertEqual)
+
+Similary, the "not_value" tests looks for values that are not what is listed in the test.
+If what is in the response is not the exact value mentioned in the test case, the test will pass.
+This is just like
+[TestCase.assertNotEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertNotEqual)
+
+###### less/not_less
+
+The "less" test looks for a value that is considered less than what is given.
+For numbers, this is the expected inequality. For strings, this is a lexicographal comparison.
+If what is tested is less than the value mentioned, the test will pass. This is just like
+[TestCase.assertLess](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLess)
+
+Similarly the "not_less" test looks for a value that is considered greater than or equal to what is given.
+If what is tested is >= than the value mentioned, the test will pass. This is just like
+[TestCase.assertGreaterEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertGreaterEqual)
+
+###### greater/not_greater
+
+The "greater" test looks for a value that is considered greater than what is given.
+For numbers, this is the expected inequality. For strings, this is a lexicographal comparison.
+If what is tested is greater than the value mentioned, the test will pass. This is just like
+[TestCase.assertGreater](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertGreater)
+
+Similarly the "not_greatre" test looks for a value that is considered less than or equal to what is given.
+If what is tested is <= than the value mentioned, the test will pass. This is just like
+[TestCase.assertLessEqual](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLessEqual)
+
+###### keywords/not_keywords
+
+The "keywords" test looks for the value mentioned to be "in" what is referred to in the response.
+For strings, this means the given keyword must be somewhere in the larger string that is being tested.
+This is just like
+[TestCase.assertIn](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertIn)
+
+Similary the not_keywords test looks for the mentioned value to be not "in" what is referred to in the response.
+This is just like
+[TestCase.assertNotIn](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertNotIn)
+
+###### gist/not_gist
+
+This one is special agent magic.
+
+The idea here is that an agent returns some string response in its multitude of ways, but you want to
+test that the string returned satisfies a certain verbally specified criteria to match all cases.
+This is *not* a strict keyword search and requires a language task to assess the validity.
+To do this we use a separate agent to test the value against the criteria to make sure the
+response matches the "gist" of the criteria.
+
+If the response from the agent we are testing matches the "gist" of the given criteria, the test passes.
+Similarly the "not_gist" test passes when the response does not match the "gist" of the given criteria.
+
+## Use with the Assessor
+
+The (Assessor)[../neuro_san/test/assesor/assessor.py) is a tool which uses these data-driven test cases
+as a basis for gathering repeated test samples so as to assess how often the test case will pass.
+You give the assessor a test case hocon file, it looks at the [success_ratio](#success-ratio) denominator
+to see how many test samples it should run.  As it gathers its output for each test sample, it
+records *how* the failures occurred and attempts to classify them according to common modes of failure.
+This allows you to get statistical picture of what you need to improve with respect to prompt or
+test case optimization.

--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -237,7 +237,7 @@ is that somewhere in the text, the keyword "Beatles" is in there.
 ##### sly_data (response)
 
 The sly_data field of the response is a dictionary describing which tests to perform
-on the sly_data dictionary optioanlly returned as part of the response from the agent's "answer".
+on the sly_data dictionary optionally returned as part of the response from the agent's "answer".
 
 Since the sly data is inherently a dictionary, we don't really want to test entire dictionary
 contents. Instead, what we want to test are specific values for particular keys inside the

--- a/tests/fixtures/music_nerd_pro/beatles_prompt.txt
+++ b/tests/fixtures/music_nerd_pro/beatles_prompt.txt
@@ -1,1 +1,0 @@
-Which band from the 60s wrote Yellow Submarine?


### PR DESCRIPTION
Document the hocon that describes the data-driven test cases under tests/fixtures.

@vince-leaf is the primary reviewer.
@kxk302 might take special interest if he is going to use the test infrastructure to help him with his fine-tuning training.