### PR TITLE
UN-3144 Potential help with timeout for long-lived chat connections.

### DIFF
--- a/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
+++ b/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
@@ -59,6 +59,9 @@ class StreamingChatHandler(BaseRequestHandler):
         """
         Implementation of POST request handler for streaming chat API call.
         """
+        self.set_header("Connection", "close")
+        # Force to close this connection without trying to reuse it.
+
         metadata: Dict[str, Any] = self.get_metadata()
         update_done: bool = await self.update_agents(metadata)
         if not update_done:


### PR DESCRIPTION
This PR is a pretty much speculative attempt to help with an issue reported by 1C group - 
some streaming chat requests not reaching neuro-san http server.
Idea (GPT suggested) that we may face a situation when long-running requests
lead to "keep-alive" server connections to be closed by a server, whereas client still trying to reuse them.
Change itself doesn't seem to affect client-initiated chats with neuro-san,
but timeout issue itself I hasn't been able to reproduce.
