### PR TITLE
Add links in hocon files to reference documentation

### DIFF
--- a/neuro_san/registries/assess_failure.hocon
+++ b/neuro_san/registries/assess_failure.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/date_time.hocon
+++ b/neuro_san/registries/date_time.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/esp_decision_assistant.hocon
+++ b/neuro_san/registries/esp_decision_assistant.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         # Demonstration of the config for llm fallbacks.

--- a/neuro_san/registries/gist.hocon
+++ b/neuro_san/registries/gist.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/hello_world.hocon
+++ b/neuro_san/registries/hello_world.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/intranet_agents.hocon
+++ b/neuro_san/registries/intranet_agents.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/manifest.hocon
+++ b/neuro_san/registries/manifest.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/manifest_hocon_reference.md
+
 {
     # Currently we list each hocon file we want to serve as a key with a boolean value.
     # Eventually we might have a dictionary value with server specifications for each.

--- a/neuro_san/registries/math_guy.hocon
+++ b/neuro_san/registries/math_guy.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/math_guy_passthrough.hocon
+++ b/neuro_san/registries/math_guy_passthrough.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/music_nerd.hocon
+++ b/neuro_san/registries/music_nerd.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/music_nerd_pro.hocon
+++ b/neuro_san/registries/music_nerd_pro.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/prebuilt_search_tool.hocon
+++ b/neuro_san/registries/prebuilt_search_tool.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/website_rag.hocon
+++ b/neuro_san/registries/website_rag.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/website_search.hocon
+++ b/neuro_san/registries/website_search.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/neuro_san/registries/website_search_usage_example.hocon
+++ b/neuro_san/registries/website_search_usage_example.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/agent_hocon_reference.md
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/tests/fixtures/esp_decision_assistant/fallbacks_and_commondef_values.hocon
+++ b/tests/fixtures/esp_decision_assistant/fallbacks_and_commondef_values.hocon
@@ -10,6 +10,9 @@
 # END COPYRIGHT
 
 # This file defines everything necessary for a data-driven test.
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/test_case_hocon_reference.md
+
 {
     # Describes what agent to test against.
     "agent": "esp_decision_assistant",

--- a/tests/fixtures/hello_world/hello_world.hocon
+++ b/tests/fixtures/hello_world/hello_world.hocon
@@ -10,6 +10,9 @@
 # END COPYRIGHT
 
 # This file defines everything necessary for a data-driven test.
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/test_case_hocon_reference.md
+
 {
     # Describes what agent to test against.
     "agent": "hello_world",

--- a/tests/fixtures/math_guy/basic_sly_data.hocon
+++ b/tests/fixtures/math_guy/basic_sly_data.hocon
@@ -10,6 +10,9 @@
 # END COPYRIGHT
 
 # This file defines everything necessary for a data-driven test.
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/test_case_hocon_reference.md
+
 {
     # Describes what agent to test against.
     "agent": "math_guy",

--- a/tests/fixtures/math_guy/forwarded_sly_data.hocon
+++ b/tests/fixtures/math_guy/forwarded_sly_data.hocon
@@ -10,6 +10,9 @@
 # END COPYRIGHT
 
 # This file defines everything necessary for a data-driven test.
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/test_case_hocon_reference.md
+
 {
     # Describes what agent to test against.
     "agent": "math_guy_passthrough",

--- a/tests/fixtures/music_nerd/beatles_with_history.hocon
+++ b/tests/fixtures/music_nerd/beatles_with_history.hocon
@@ -10,6 +10,9 @@
 # END COPYRIGHT
 
 # This file defines everything necessary for a data-driven test.
+# The schema specifications for this file are documented here:
+# https://github.com/leaf-ai/neuro-san/blob/main/docs/test_case_hocon_reference.md
+
 {
     # Describes what agent to test against.
     "agent": "music_nerd",


### PR DESCRIPTION
Like the title says, add links (in comments) to:
* manifest.hocon to manifest_hocon_reference.md
* agent.hocon files to agent_hocon_reference.md
* test case.hocon files to test_case_hocon_reference.md

the default_llm_info.hocon already as a link to its reference docs.

Folks should consider similar links for neuro-san-demos.