### PR TITLE
Fixes for tornado handlers.

### DIFF
--- a/neuro_san/http_sidecar/handlers/concierge_handler.py
+++ b/neuro_san/http_sidecar/handlers/concierge_handler.py
@@ -41,5 +41,5 @@ class ConciergeHandler(BaseRequestHandler):
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.process_exception(exc)
         finally:
-            self.flush()
+            self.do_finish()
             self.logger.info(metadata, "Finish GET /api/v1/list")

--- a/neuro_san/http_sidecar/handlers/connectivity_handler.py
+++ b/neuro_san/http_sidecar/handlers/connectivity_handler.py
@@ -35,7 +35,7 @@ class ConnectivityHandler(BaseRequestHandler):
         if not self.agent_policy.allow(agent_name):
             self.set_status(404)
             self.logger.error({}, "error: Invalid request path %s", self.request.path)
-            await self.flush()
+            self.do_finish()
             return
 
         self.logger.info(metadata, "Start GET %s/connectivity", agent_name)
@@ -51,5 +51,5 @@ class ConnectivityHandler(BaseRequestHandler):
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.process_exception(exc)
         finally:
-            await self.flush()
+            self.do_finish()
             self.logger.info(metadata, "Finish GET %s/connectivity request", agent_name)

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -35,7 +35,7 @@ class FunctionHandler(BaseRequestHandler):
         if not self.agent_policy.allow(agent_name):
             self.set_status(404)
             self.logger.error({}, "error: Invalid request path %s", self.request.path)
-            await self.flush()
+            self.do_finish()
             return
 
         self.logger.info(metadata, "Start GET %s/function", agent_name)
@@ -52,5 +52,5 @@ class FunctionHandler(BaseRequestHandler):
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.process_exception(exc)
         finally:
-            await self.flush()
+            self.do_finish()
             self.logger.info(metadata, "Finish GET %s/function", agent_name)

--- a/neuro_san/http_sidecar/handlers/health_check_handler.py
+++ b/neuro_san/http_sidecar/handlers/health_check_handler.py
@@ -38,7 +38,7 @@ class HealthCheckHandler(RequestHandler):
             self.set_status(500)
             self.write({"error": "Internal server error"})
         finally:
-            await self.flush()
+            self.finish()
 
     def data_received(self, chunk):
         """

--- a/neuro_san/http_sidecar/handlers/openapi_publish_handler.py
+++ b/neuro_san/http_sidecar/handlers/openapi_publish_handler.py
@@ -39,5 +39,5 @@ class OpenApiPublishHandler(BaseRequestHandler):
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.process_exception(exc)
         finally:
-            self.flush()
+            self.do_finish()
             self.logger.info(metadata, "Finish GET /api/v1/docs")

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -93,7 +93,6 @@ class HttpServiceAgentSession(AgentSession):
         headers: Dict[str, Any] = self.metadata
         if headers is None:
             headers = {}
-        headers["Connection"] = "close"
         return headers
 
     def help_message(self, path: str) -> str:


### PR DESCRIPTION
This PR implements several fixes to neuro-san Tornado request handlers.

- Make sure that handler.finish() is always called directly, not awaited, as recommended by Tornado docs;
- We add logging for possible tornado.iostream.StreamClosedError exception;
- Connections are back to being keep-alive by default, since this doesn't seem to be the source of issues we observe.

Tested by running local mini stress test:
3 clients each running 30x3 chat requests - around 1000 chat results in total. Server survives. 
