### PR TITLE
UN-3131 remove command key from coded tool nodes in neuro-san

### DIFF
--- a/neuro_san/registries/music_nerd_pro.hocon
+++ b/neuro_san/registries/music_nerd_pro.hocon
@@ -91,7 +91,6 @@ to the API to get the updated running cost. If no running cost it known, pass 0.
                 }
             },
             "class": "accounting.Accountant",
-            "command": "Call the API to compute the new running cost."
         },
     ]
 }

--- a/neuro_san/registries/website_search.hocon
+++ b/neuro_san/registries/website_search.hocon
@@ -76,7 +76,6 @@ Assist caller with searching an url on the web by using your tool.
                 }
             },
             "class": "website_search.WebsiteSearch",
-            "command": "Call the API to get a list of URLs for available options."
         },
     ]
 }


### PR DESCRIPTION
Remove `command` from the coded tools in `music_nerd_pro.hocon` and `website_search.hocon`