### PR TITLE
UN-3155 Polling agents registry updater.

### DIFF
--- a/neuro_san/service/registries_watcher/periodic_updater/registry_event_observer.py
+++ b/neuro_san/service/registries_watcher/periodic_updater/registry_event_observer.py
@@ -17,7 +17,7 @@ from watchdog.observers import Observer
 from neuro_san.service.registries_watcher.periodic_updater.registry_change_handler import RegistryChangeHandler
 
 
-class RegistryObserver:
+class RegistryEventObserver:
     """
     Observer class for manifest file and its directory.
     """

--- a/neuro_san/service/registries_watcher/periodic_updater/registry_polling_observer.py
+++ b/neuro_san/service/registries_watcher/periodic_updater/registry_polling_observer.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+import logging
+from typing import Tuple
+from pathlib import Path
+from watchdog.observers.polling import PollingObserver
+
+from neuro_san.service.registries_watcher.periodic_updater.registry_change_handler import RegistryChangeHandler
+
+
+class RegistryPollingObserver:
+    """
+    Observer class for manifest file and its directory.
+    """
+
+    def __init__(self, manifest_path: str, poll_seconds: int):
+        self.manifest_path: str = str(Path(manifest_path).resolve())
+        self.registry_path: str = str(Path(self.manifest_path).parent)
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.poll_seconds = poll_seconds
+        self.observer: PollingObserver = PollingObserver(timeout=self.poll_seconds)
+        self.event_handler: RegistryChangeHandler = RegistryChangeHandler()
+
+    def start(self):
+        """
+        Start running observer
+        """
+        self.observer.schedule(self.event_handler, path=self.registry_path, recursive=False)
+        self.observer.start()
+        self.logger.info("Registry polling watchdog started on: %s for manifest %s with polling every %d sec",
+                         self.registry_path, self.manifest_path, self.poll_seconds)
+
+    def reset_event_counters(self) -> Tuple[int, int, int]:
+        """
+        Reset event counters and return current counters.
+        """
+        return self.event_handler.reset_event_counters()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common==1.2.21
+leaf-common==1.2.22
 leaf-server-common==0.1.18
 
 # These are needed for generating code from .proto files

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 # In-house dependencies
 leaf-common==1.2.22
-leaf-server-common==0.1.18
+leaf-server-common==0.1.19
 
 # These are needed for generating code from .proto files
 grpcio>=1.62.0


### PR DESCRIPTION
This PR implements another version of agents registry updater - the one that goes for direct polling of target registry directory instead of relying on OS-level file system events.
OS-level events work just fine for truly local setup,
but have problems if we deal with mapped storage volumes, especially if file system of different kinds are mixed.
Polling is much more reliable, but relatively CPU-intensive.

Tested: running neuro-san server in a Docker container, with registry mapped to host-side directory.
Changes in this directory are detected by the server with proper reaction.
Also: running medium stability test with another script periodically updating agents registry.
 
